### PR TITLE
Update 30_benchmark.jl

### DIFF
--- a/_AUTO_BENCHMARK/src/30_benchmark.jl
+++ b/_AUTO_BENCHMARK/src/30_benchmark.jl
@@ -33,7 +33,7 @@ println("done.")
 # warming up
 println("warming up...")
 base = base_all[1]
-test = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1)))
+test = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 println("done.")
 
 # 1 FE
@@ -45,13 +45,13 @@ for i = 1:40
     println("i = ", i)
     base = base_all[i]
     print(size(base))
-    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1)))
+    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
 for i = 1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1)))
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
@@ -67,13 +67,13 @@ timings = Vector{Float64}(undef, 50)
 for i = 1:40
     println("i = ", i)
     base = base_all[i]
-    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2)))
+    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
 for i = 1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2)))
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
@@ -90,13 +90,13 @@ timings = Vector{Float64}(undef, 50)
 for i = 1:40
     println("i = ", i)
     base = base_all[i]
-    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)))
+    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
 for i = 1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)))
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
@@ -118,7 +118,7 @@ println("done.")
 # warming up
 println("warming up...")
 base = base_diff[1]
-test = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)))
+test = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)), tol = 1e-6, drop_singletons = false)
 println("done.")
 
 timings = Vector{Float64}(undef, 120)
@@ -131,11 +131,11 @@ for size = 1:4
         println("g = ", g)
         for r = 1:10
             if g == 1
-                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)))
+                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)), tol = 1e-6, drop_singletons = false)
             elseif g == 2
-                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv) + fe(id_firm)))
+                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv) + fe(id_firm)), tol = 1e-6, drop_singletons = false)
             else
-                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv) + fe(id_firm) + fe(id_year)))
+                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv) + fe(id_firm) + fe(id_year)), tol = 1e-6, drop_singletons = false)
             end
             global index = index + 1
         end

--- a/_BENCHMARK/Benchmark.jl
+++ b/_BENCHMARK/Benchmark.jl
@@ -3,7 +3,8 @@ Benchmark:
 - Julia version: 1.2.0
 - Author: laurent.berge
 - Date: 2019-11-13
-- ~: Replication in Julia =#
+- ~: Replication in Julia
+=#
 
 #=
 using Pkg
@@ -12,27 +13,26 @@ Pkg.add("DelimitedFiles")
 Pkg.add("FixedEffectModels")
 Pkg.add("DataFrames")
 Pkg.add("CSV")
-pwd()
-cd("./Google Drive/R_packages/fixest/fixest/_BENCHMARK") =#
 
-DATA_DIR = "data"
-RESULTS_DIR = "results"
+pwd()
+cd("./Google Drive/R_packages/fixest/fixest/_BENCHMARK")
+=#
 
 println("Loading packages...")
 using RData, DelimitedFiles, FixedEffectModels, DataFrames, CSV
 println("done.")
 
 println("Loading data...")
-base_all = load(joinpath(DATA_DIR, "base_all_simulations.RData"), convert=true);
+base_all = load("DATA/base_all_simulations.RData", convert=true);
 base_all = base_all["base_all"];
 println(".")
-base_10M = CSV.read(joinpath(DATA_DIR, "base_10M.csv"), DataFrame)
+base_10M = CSV.read("DATA/base_10M.csv", DataFrame)
 println("done.")
 
 # warming up
 println("warming up...")
 base = base_all[1]
-test = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
+test = @elapsed reg(base, @formula(ln_y~X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 println("done.")
 
 # 1 FE
@@ -40,45 +40,45 @@ println("done.")
 # We run all the models
 println("One FE.")
 timings = Vector{Float64}(undef, 50)
-for i = 1:40
+for i=1:40
     println("i = ", i)
     base = base_all[i]
     print(size(base))
-    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
+    timings[i] = @elapsed reg(base, @formula(ln_y~X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
-for i = 1:10
+for i=1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y~X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
-open(joinpath(RESULTS_DIR, "julia_bench_1FE.txt"), "w") do io
-    writedlm(io, timings)
-end
+open("DATA/julia_bench_1FE.txt", "w") do io
+           writedlm(io, timings)
+       end
 
 # 2 FE
 
 # We run all the models
 println("Two FEs.")
 timings = Vector{Float64}(undef, 50)
-for i = 1:40
+for i=1:40
     println("i = ", i)
     base = base_all[i]
-    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2)), tol = 1e-6, drop_singletons = false)
+    timings[i] = @elapsed reg(base, @formula(ln_y~X1 + fe(dum_1) + fe(dum_2)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
-for i = 1:10
+for i=1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2)), tol = 1e-6, drop_singletons = false)
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y~X1 + fe(dum_1) + fe(dum_2)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
-open(joinpath(RESULTS_DIR, "julia_bench_2FE.txt"), "w") do io
-    writedlm(io, timings)
-end
+open("DATA/julia_bench_2FE.txt", "w") do io
+           writedlm(io, timings)
+       end
 
 
 # 3 FE
@@ -86,22 +86,22 @@ end
 # We run all the models
 println("Three FEs.")
 timings = Vector{Float64}(undef, 50)
-for i = 1:40
+for i=1:40
     println("i = ", i)
     base = base_all[i]
-    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)), tol = 1e-6, drop_singletons = false)
+    timings[i] = @elapsed reg(base, @formula(ln_y~X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
-for i = 1:10
+for i=1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)), tol = 1e-6, drop_singletons = false)
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y~X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
-open(joinpath(RESULTS_DIR, "julia_bench_3FE.txt"), "w") do io
-    writedlm(io, timings)
-end
+open("DATA/julia_bench_3FE.txt", "w") do io
+           writedlm(io, timings)
+       end
 
 
 
@@ -110,7 +110,7 @@ end
 #
 
 println("Loading difficult data...")
-base_diff = load(joinpath(DATA_DIR, "base_all_diff.RData"), convert=true);
+base_diff = load("DATA/base_all_diff.RData", convert=true);
 base_diff = base_diff["base_all_diff"];
 println("done.")
 
@@ -123,12 +123,12 @@ println("done.")
 timings = Vector{Float64}(undef, 120)
 
 global index = 1
-for size = 1:4
+for size=1:4
     println("size = ", size)
     base = base_diff[size]
-    for g = 1:3
+    for g=1:3
         println("g = ", g)
-        for r = 1:10
+        for r=1:10
             if g == 1
                 global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)), tol = 1e-6, drop_singletons = false)
             elseif g == 2
@@ -142,6 +142,6 @@ for size = 1:4
 end
 
 # saving
-open(joinpath(RESULTS_DIR, "julia_bench_diff.txt"), "w") do io
-    writedlm(io, timings)
-end
+open("DATA/julia_bench_diff.txt", "w") do io
+           writedlm(io, timings)
+       end

--- a/_BENCHMARK/Benchmark.jl
+++ b/_BENCHMARK/Benchmark.jl
@@ -3,8 +3,7 @@ Benchmark:
 - Julia version: 1.2.0
 - Author: laurent.berge
 - Date: 2019-11-13
-- ~: Replication in Julia
-=#
+- ~: Replication in Julia =#
 
 #=
 using Pkg
@@ -13,26 +12,27 @@ Pkg.add("DelimitedFiles")
 Pkg.add("FixedEffectModels")
 Pkg.add("DataFrames")
 Pkg.add("CSV")
-
 pwd()
-cd("./Google Drive/R_packages/fixest/fixest/_BENCHMARK")
-=#
+cd("./Google Drive/R_packages/fixest/fixest/_BENCHMARK") =#
+
+DATA_DIR = "data"
+RESULTS_DIR = "results"
 
 println("Loading packages...")
 using RData, DelimitedFiles, FixedEffectModels, DataFrames, CSV
 println("done.")
 
 println("Loading data...")
-base_all = load("DATA/base_all_simulations.RData", convert=true);
+base_all = load(joinpath(DATA_DIR, "base_all_simulations.RData"), convert=true);
 base_all = base_all["base_all"];
 println(".")
-base_10M = CSV.read("DATA/base_10M.csv", DataFrame)
+base_10M = CSV.read(joinpath(DATA_DIR, "base_10M.csv"), DataFrame)
 println("done.")
 
 # warming up
 println("warming up...")
 base = base_all[1]
-test = @elapsed reg(base, @formula(ln_y~X1 + fe(dum_1)))
+test = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 println("done.")
 
 # 1 FE
@@ -40,45 +40,45 @@ println("done.")
 # We run all the models
 println("One FE.")
 timings = Vector{Float64}(undef, 50)
-for i=1:40
+for i = 1:40
     println("i = ", i)
     base = base_all[i]
     print(size(base))
-    timings[i] = @elapsed reg(base, @formula(ln_y~X1 + fe(dum_1)))
+    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
-for i=1:10
+for i = 1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y~X1 + fe(dum_1)))
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
-open("DATA/julia_bench_1FE.txt", "w") do io
-           writedlm(io, timings)
-       end
+open(joinpath(RESULTS_DIR, "julia_bench_1FE.txt"), "w") do io
+    writedlm(io, timings)
+end
 
 # 2 FE
 
 # We run all the models
 println("Two FEs.")
 timings = Vector{Float64}(undef, 50)
-for i=1:40
+for i = 1:40
     println("i = ", i)
     base = base_all[i]
-    timings[i] = @elapsed reg(base, @formula(ln_y~X1 + fe(dum_1) + fe(dum_2)))
+    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
-for i=1:10
+for i = 1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y~X1 + fe(dum_1) + fe(dum_2)))
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
-open("DATA/julia_bench_2FE.txt", "w") do io
-           writedlm(io, timings)
-       end
+open(joinpath(RESULTS_DIR, "julia_bench_2FE.txt"), "w") do io
+    writedlm(io, timings)
+end
 
 
 # 3 FE
@@ -86,22 +86,22 @@ open("DATA/julia_bench_2FE.txt", "w") do io
 # We run all the models
 println("Three FEs.")
 timings = Vector{Float64}(undef, 50)
-for i=1:40
+for i = 1:40
     println("i = ", i)
     base = base_all[i]
-    timings[i] = @elapsed reg(base, @formula(ln_y~X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)))
+    timings[i] = @elapsed reg(base, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)), tol = 1e-6, drop_singletons = false)
 end
 
 # The 10M DB
-for i=1:10
+for i = 1:10
     println("i = ", i + 40)
-    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y~X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)))
+    timings[i + 40] = @elapsed reg(base_10M, @formula(ln_y ~ X1 + fe(dum_1) + fe(dum_2) + fe(dum_3)), tol = 1e-6, drop_singletons = false)
 end
 
 # saving
-open("DATA/julia_bench_3FE.txt", "w") do io
-           writedlm(io, timings)
-       end
+open(joinpath(RESULTS_DIR, "julia_bench_3FE.txt"), "w") do io
+    writedlm(io, timings)
+end
 
 
 
@@ -110,31 +110,31 @@ open("DATA/julia_bench_3FE.txt", "w") do io
 #
 
 println("Loading difficult data...")
-base_diff = load("DATA/base_all_diff.RData", convert=true);
+base_diff = load(joinpath(DATA_DIR, "base_all_diff.RData"), convert=true);
 base_diff = base_diff["base_all_diff"];
 println("done.")
 
 # warming up
 println("warming up...")
 base = base_diff[1]
-test = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)))
+test = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)), tol = 1e-6, drop_singletons = false)
 println("done.")
 
 timings = Vector{Float64}(undef, 120)
 
 global index = 1
-for size=1:4
+for size = 1:4
     println("size = ", size)
     base = base_diff[size]
-    for g=1:3
+    for g = 1:3
         println("g = ", g)
-        for r=1:10
+        for r = 1:10
             if g == 1
-                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)))
+                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv)), tol = 1e-6, drop_singletons = false)
             elseif g == 2
-                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv) + fe(id_firm)))
+                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv) + fe(id_firm)), tol = 1e-6, drop_singletons = false)
             else
-                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv) + fe(id_firm) + fe(id_year)))
+                global timings[index] = @elapsed reg(base, @formula(y ~ x1 + x2 + fe(id_indiv) + fe(id_firm) + fe(id_year)), tol = 1e-6, drop_singletons = false)
             end
             global index = index + 1
         end
@@ -142,6 +142,6 @@ for size=1:4
 end
 
 # saving
-open("DATA/julia_bench_diff.txt", "w") do io
-           writedlm(io, timings)
-       end
+open(joinpath(RESULTS_DIR, "julia_bench_diff.txt"), "w") do io
+    writedlm(io, timings)
+end


### PR DESCRIPTION
Great package! Thanks for comparing the performances with FixedEffectModels.jl. 

I'd be curious to know what happens if you use the same options in FixedEffectModels.jl and `feols` — in particular `feols` uses `tol=1e-6` while FixedEffectModels uses `tol = 1e-8` by default (similarly to `reghdfe` or `lfe`).

I have not included this in the PR, but another thing would be to use the same number of threads in julia (i.e. start julia with `julia --threads 4`, say)