### PR TITLE
Fix documentation bug

### DIFF
--- a/R/VCOV.R
+++ b/R/VCOV.R
@@ -1089,7 +1089,7 @@ vcov.fixest = function(object, vcov = NULL, se = NULL, cluster, ssc = NULL, attr
 #' # Default: fixef.K = "nested"
 #' #  => adjustment K = 1 + 5 (i.e. x + fe2)
 #' summary(est)
-#' attributes(vcov(est, attr = TRUE))[c("ssc.type", "dof.K")]
+#' attributes(vcov(est, attr = TRUE))[c("ssc", "dof.K")]
 #'
 #'
 #' # fixef.K = FALSE


### PR DESCRIPTION
There is no `ssc.type` attribute. It should just be `ssc`

https://github.com/lrberge/fixest/blob/187cedce5e4b8d38f4024dc861ed717c7f0d7e6b/R/VCOV.R#L1092