### PR TITLE
Minor speed improvement

### DIFF
--- a/R/Methods.R
+++ b/R/Methods.R
@@ -952,7 +952,7 @@ fixef.fixest = function(object, notes = getFixest_notes(), sorted = TRUE, nthrea
 
         nthreads = check_set_nthreads(nthreads)
 
-        table_id_I = as.integer(unlist(lapply(fe_id_list, table), use.names = FALSE))
+        table_id_I = as.integer(unlist(lapply(fe_id_list, tabulate), use.names = FALSE))
 
         S_demean = cpp_demean(y = S, X_raw = 0, r_weights = 0, iterMax = as.integer(fixef.iter),
                               diffMax = fixef.tol, r_nb_id_Q = fixef_sizes,
@@ -1102,7 +1102,7 @@ fixef.fixest = function(object, notes = getFixest_notes(), sorted = TRUE, nthrea
                 fixef_sizes = fixef_sizes[new_order]
 
                 fe_id_list = object$fixef_id[new_order]
-                table_id_I = as.integer(unlist(lapply(fe_id_list, table), use.names = FALSE))
+                table_id_I = as.integer(unlist(lapply(fe_id_list, tabulate), use.names = FALSE))
 
                 slope_flag = rep(0L, Q)
                 slope_variables = list()

--- a/R/Methods.R
+++ b/R/Methods.R
@@ -2603,7 +2603,7 @@ predict.fixest = function(object, newdata, type = c("response", "link"), se.fit 
         }
 
         var_keep = intersect(names(coef), colnames(matrix_linear))
-        value_linear = value_linear + c(matrix_linear[, var_keep, drop = FALSE] %*% coef[var_keep])
+        value_linear = value_linear + as.vector(matrix_linear[, var_keep, drop = FALSE] %*% coef[var_keep])
     }
 
     #


### PR DESCRIPTION
Minor improvement: use `tabulate()` instead of `table()`.

`table()` returns a named vector and `tabulate()` returns an unnamed vector, but that doesn't matter here because you remove the names anyway:
``` r
set.seed(123)
foo <- sample(1:100, 1e7, TRUE)
bench::mark(
    tabulate(foo),
    table(foo),
    iterations = 20,
    check = FALSE
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tabulate(foo)   12.5ms   13.5ms     72.9     12.8KB     0   
#> 2 table(foo)     551.6ms  649.4ms      1.54   662.2MB     7.86
```

<sup>Created on 2023-02-22 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>


I ran the tests locally and everything looked fine.