### PR TITLE
Fix: Render CRAN status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # fixest: Fast and user-friendly fixed-effects estimation
 
-<a href="https://cran.r-project.org/web/checks/check_results_fixest.html"><img src="https://cranchecks.info/badges/worst/fixest" alt="CRAN status"></a>
+<a href="https://cran.r-project.org/web/checks/check_results_fixest.html"><img src="https://www.r-pkg.org/badges/version/fixest" alt="CRAN status"></a>
 <a href="https://fastverse.r-universe.dev"><img src="https://fastverse.r-universe.dev/badges/fixest" alt="Version_ROpensci"></a>
 <a href="https://CRAN.R-project.org/package=fixest"><img src="http://www.r-pkg.org/badges/version/fixest" alt="Version"> </a>
 <a href="https://ipub.com/dev-corner/apps/r-package-downloads/"> <img src="https://cranlogs.r-pkg.org/badges/fixest" alt = "Downloads"> </a>


### PR DESCRIPTION
[cranchecks](https://cranchecks.info) is not functional anymore. Hence redirected to a functional link for proper rendering of status badge.