### PR TITLE
`pkgdown`: use bootstrap 5

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,5 @@
+url: https://lrberge.github.io/fixest/
+
 template:
   bootstrap: 5
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,5 @@
-
+template:
+  bootstrap: 5
 
 title: fixest
 


### PR DESCRIPTION
In addition to modifying the style, this adds a search bar on the website (see e.g the [marginaleffects](https://vincentarelbundock.github.io/marginaleffects/) website), which is something I find very useful to quickly find specific content across vignettes.

Matter of taste of course ;-)

(See the [`pkgdown` vignette on "Search"](https://pkgdown.r-lib.org/articles/search.html#bootstrap-5-built-in-search) if you want to try it locally first)