### PR TITLE
Use t-distribution for `coefplot`/`iplot` CIs

### DIFF
--- a/R/coefplot.R
+++ b/R/coefplot.R
@@ -1445,7 +1445,7 @@ coefplot = function(object, ..., style = NULL, sd, ci_low, ci_high, x, x.shift =
 
 
 coefplot_prms = function(object, ..., sd, ci_low, ci_high, x, x.shift = 0, dict,
-                         keep, drop, order, ci_level = 0.95, ref = "auto",
+                         keep, drop, order, ci_level = 0.95, dof = NULL, ref = "auto",
                          only.i = TRUE, sep, as.multiple = FALSE){
 
     # get the default for:
@@ -1622,11 +1622,13 @@ coefplot_prms = function(object, ..., sd, ci_low, ci_high, x, x.shift = 0, dict,
 
             names(estimate) = rownames(mat)
 
-            if("fml" %in% names(object)){
+            if ("fml" %in% names(object)) {
                 depvar = gsub(" ", "", as.character(object$fml)[[2]])
-                if(depvar %in% names(dict)) depvar = dict[depvar]
+                if (depvar %in% names(dict)) depvar = dict[depvar]
                 varlist$depvar = depvar
             }
+            
+            dof = tryCatch(degrees_freedom(object, "t"), error = function(e) NULL)
 
         } else if(is.matrix(object)){
             # object is a matrix containing the coefs and SEs
@@ -1658,7 +1660,8 @@ coefplot_prms = function(object, ..., sd, ci_low, ci_high, x, x.shift = 0, dict,
             if(!missing(ci_low) || !missing(ci_high)) warning("Since 'sd' is provided, arguments 'ci_low' or 'ci_high' are ignored.")
 
             # We compute the CI
-            nb = abs(qnorm((1 - ci_level)/2))
+            if (is.null(dof)) dof = Inf
+            nb = abs(qt((1 - ci_level) / 2, df = dof))
             ci_high = estimate + nb*sd
             ci_low = estimate - nb*sd
         }

--- a/tests/fixest_tests.R
+++ b/tests/fixest_tests.R
@@ -2170,13 +2170,14 @@ est = feols(y ~ x1 + x2 | species, base)
 test(nrow(confint(est)), 2)
 test(nrow(confint(est, "x1")), 1)
 
+est_coefplot_prms = coefplot(est, only.params = TRUE)$prms[, 2:3]
+test(confint(est), est_coefplot_prms)
+
 est_pois = fepois(y ~ x1 | species, base)
 test(nrow(confint(est_pois)), 1)
 
-
 est_iv = feols(y ~ x1 | species | x2 ~ x3, base)
 test(nrow(confint(est_iv)), 2)
-
 
 ####
 #### etable ####


### PR DESCRIPTION
Almost all of the dedicated **fixest** methods that yield confidence intervals do so using a t-distribution. (See also https://github.com/lrberge/fixest/issues/362#issuecomment-1275200731.) A notable exception can be found in the `coefplot`/`iplot`  functions, which currently use a normal distribution: 

https://github.com/lrberge/fixest/blob/d8fb28abb9cca39da28697ec705a1a10169423d7/R/coefplot.R#L1660-L1661

The importance of this difference obviously diminishes with the size of the dataset (since DoF -> Inf). But it does create an awkward situation where the figures from `coefplot`/`iplot` don't necessarily correspond to the results from, say, `etable`.

This PR brings the CIs from `coefplot` and `iplot` into alignment with the other **fixest** methods. I've tried to include some catches so that, if it can't extract the right DoF from the model object for some reason, it will default to Inf and thus effectively revert back to a normal distribution.

Here is the current behaviour (**fixest** 0.11.1):

``` r
library(fixest)

base = setNames(iris, c("y", "x1", "x2", "x3", "species"))
est = feols(y ~ x1 + x2 | species, base)

confint(est)
#>         2.5 %   97.5 %
#> x1 -0.2618362 1.126271
#> x2  0.2311479 1.320111
coefplot(est, only.params = TRUE)$prms[, 2:3]
#>       ci_low   ci_high
#> x1 0.1160589 0.7483756
#> x2 0.5276048 1.0236542
```

<sup>Created on 2023-04-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

And the same code following this PR:

``` r
devtools::load_all("~/Documents/Projects/fixest")
#> ℹ Loading fixest

base = setNames(iris, c("y", "x1", "x2", "x3", "species"))
est = feols(y ~ x1 + x2 | species, base)

confint(est)
#>         2.5 %   97.5 %
#> x1 -0.2618362 1.126271
#> x2  0.2311479 1.320111
coefplot(est, only.params = TRUE)$prms[, 2:3]
#>        ci_low  ci_high
#> x1 -0.2618362 1.126271
#> x2  0.2311479 1.320111
```

<sup>Created on 2023-04-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>