### PR TITLE
Added support methods for emmeans

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R:
              email = "grantmcd@uoregon.edu",
              comment = c(ORCID = "0000-0001-7883-8573")))
 Imports: stats, graphics, grDevices, tools, utils, methods, numDeriv, nlme, sandwich, Rcpp(>= 1.0.5), dreamerr(>= 1.2.3)
-Suggests: knitr, rmarkdown, data.table, plm, MASS, pander, ggplot2, lfe, tinytex, pdftools
+Suggests: knitr, rmarkdown, data.table, plm, MASS, pander, ggplot2, lfe, tinytex, pdftools, emmeans
 LinkingTo: Rcpp
 Depends: R(>= 3.5.0)
 Description: Fast and user-friendly estimation of econometric models with multiple fixed-effects. Includes ordinary least squares (OLS), generalized linear models (GLM) and the negative binomial.

--- a/R/emmeans-support.R
+++ b/R/emmeans-support.R
@@ -1,0 +1,97 @@
+##### emmeans support
+##### contributed by Russ Lenth russell-lenth[at]uiowa.edu
+
+### CAUTION: For models with fixed effects, this code will yield the correct estimates
+### of estimated marginal means -- but the wrong SEs because the intercept is among
+### the fixed effects, hence not included in vcov(). CONTRASTS among EMMs will
+### work fine because those give zero weight to the intercept.
+
+### Another note: Only main model predictors are included in the reference grid.
+### Not any fixed effects, not any instrumental variables
+
+#' Support for emmeans package
+#'
+#' If \pkg{emmeans} is installed, its functionality is supported for \code{fixest}
+#' or \code{fixest_multi} objects. Its reference grid is based on the main part
+#' of the model, and does not include fixed effects or instrumental variables.
+#' Note that any desired arguments to \code{vcov()} may be passed as optional
+#' arguments in \code{emmeans::emmeans()} or \code{emmeans::ref_grid()}.
+#'
+#' @note
+#' When fixed effects are present, estimated marginal means (EMMs) are estimated
+#' correctly, provided equal weighting is used. However, the SEs of these EMMs
+#' will be incorrect - often dramatically - because the estimated variance of
+#' the intercept is not available. However, \emph{contrasts} among EMMs can be
+#' estimated and tested with no issues, because these do not involve the
+#' intercept.
+#'
+#' @examples
+#' if(requireNamespace("emmeans") && requireNamespace(AER)) {
+#'     data(Fatalities, package = "AER")
+#'     Fatalities$frate <- with(Fatalities, fatal/pop * 10000)
+#'     fat.mod = feols(frate ~ breath * jail * beertax | state + year, data = Fatalities)
+#'     emm = emmeans(fat.mod, ~ breath*jail, cluster = ~ state + year)
+#'     emm   ### SEs and CIs are incorrect
+#'
+#'     contrast(emm, "consec", by = "breath")   ### results are reliable
+#' }
+#' @name emmeans_support
+NULL
+
+
+### DO NOT export - this is done dynamically in .onLoad()
+recover_data.fixest = function (object, ...) {
+    fcall = object$call
+    dat = recover_data(fcall, delete.response(terms(object)), object$na.action,
+                       pwts = weights(object), ...)
+    if(!is.character(dat)) { # i.e., we actually did recover data
+        # if any fixed effects, make them a prior offset
+        fe = try(fixef(object), silent = TRUE)
+        if(!inherits(fe, "try-error")) {
+            dat$.static.offset. = sum(sapply(fe, mean))
+            attr(dat, "predictors") = c(attr(dat, "predictors"), ".static.offset.")
+        }
+    }
+    dat
+}
+
+emm_basis.fixest = function(object, trms, xlev, grid, ...) {
+    bhat = coef(object)
+    nm = if(is.null(names(bhat))) row.names(bhat) else names(bhat)
+    m = suppressWarnings(model.frame(trms, grid, na.action = na.pass, xlev = xlev))
+    X = model.matrix(trms, m, contrasts.arg = object$contrasts)
+    assign = attr(X, "assign")
+    X = X[, nm, drop = FALSE]
+    bhat = as.numeric(bhat)
+    V = vcov(object, ...) # we're using fixest's method as it already allows vcov option
+
+    # fixest handles rank deficiencies by tossing columns. Plus it seems hard to
+    # recover the needed portion of X after the fixed effects are orthogonalized out.
+    # So at this point we are just ignoring non-estimability issues (and generally
+    # bhat will NOT be aligned with linfct, creating mysterious errors downstream)
+    nbasis = estimability::all.estble
+
+    misc = list()
+    if (!is.null(fam<- object$family)) {
+        if(is.character(fam))
+            fam = list(family = fam, link = "identity")
+        misc = .std.link.labels(fam, misc)
+        dfargs = list(df = Inf)
+    }
+    else
+        dfargs = list(df = object$nobs - object$nparams)
+    dffun = function(k, dfargs) dfargs$df
+    list(X=X, bhat=bhat, nbasis=nbasis, V=V, dffun=dffun, dfargs=dfargs, misc=misc,
+         model.matrix = .cmpMM(object$qr, assign = assign))
+}
+
+# multi methods ------------------------------------------------
+recover_data.fixest_multi = function(object, which, ...) {
+    if(missing(which))
+        return("For 'fixest_multi' objects, you must use 'which' to specify which response to use.")
+    recover_data.fixest(object[[which]], ...)
+}
+
+emm_basis.fixest_multi = function(object, trms, xlev, grid, which, ...)
+    emm_basis.fixest(object[[which]], trms, xlev, grid, ...)
+

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -29,6 +29,10 @@
     # To circumvent a peculiar behavior from pkgdown
     fix_pkgwdown_path()
 
+    # register emmeans methods
+    if (requireNamespace("emmeans", quietly = TRUE))
+        emmeans::.emm_register(c("fixest", "fixest_multi"), pkgname)
+
 	invisible()
 }
 


### PR DESCRIPTION
Following-up on an **emmeans** user's suggestion. I have put together some support methods for the **emmeans** package. With it set up as provided, these methods will be registered when **fixest** is loaded, provided that **emmeans** is installed.

The provided example uses the **AER** package. I just didn't want to do an example with the `iris` data, as it is so far afield of the kinds of applications we would want with **fixest**. I think your package would benefit from having at least a somewhat realistic econometric example dataset built-in.

There are some important notes in the ROxygen comments. Only the variables in the main model are considered in the reference grid created by `emmeans` -- no fixed effects nor instrumental variables. Your `vcov` and other optional arguments to `vcov()` are supported via optional arguments to `emmeans()`. And an important consideration: while the *estimates* of marginal means are correct, their standard errors and CIs are incorrect when we have fixed effects, because the EMMs involve the intercept for which we don't have variances and covariances; however, contrasts among EMMs are fine because the intercept is zeroed-out.