### PR TITLE
Improvements to `etable`

### DIFF
--- a/R/etable.R
+++ b/R/etable.R
@@ -5343,7 +5343,12 @@ build_tex_png = function(x, view = FALSE, export = NULL, markdown = NULL,
     # (In regular markdown, the temp dir is a bit more elegant since
     #  it does not clutter the workspace)
 
-    markdown = "./images/etable/"
+    markdown = file.path(
+      knitr::opts_knit$get("output.dir"), 
+      knitr::fig_path('.png')
+    )
+    markdown = dirname(markdown)
+    # markdown = "./images/etable/"
   }
 
   # we need to clean all the tmp tags otherwise the caching does not work
@@ -5360,7 +5365,7 @@ build_tex_png = function(x, view = FALSE, export = NULL, markdown = NULL,
   do_build = TRUE
   export_markdown = id = NULL
   if(!is.null(markdown)){
-    markdown_path = check_set_path(markdown, "w, dir", create = TRUE, up = up)
+    markdown_path = check_set_path(markdown, "w, dir", create = TRUE, up = up, recursive = TRUE)
 
     all_files = list.files(markdown_path, "\\.png$", full.names = TRUE)
     id_all = gsub("^.+_|\\.png$", "", all_files)
@@ -5698,7 +5703,9 @@ check_set_path = function(x, type = "", create = TRUE, up = 0, recursive = FALSE
   if(nchar(path_dir) == 0) path_dir = "."
 
   if(create & recursive) {
-    dir.create(path, recursive = TRUE)
+    if(!dir.exists(path)) {
+      dir.create(path, recursive = TRUE)
+    }
   }
 
   path_parent = dirname(path)

--- a/R/etable.R
+++ b/R/etable.R
@@ -939,7 +939,7 @@ etable = function(..., vcov = NULL, stage = 2, agg = NULL,
   # Arguments that can be set globally
   opts = getOption("fixest_etable")
 
-  args_global = c("postprocess.tex", "postprocess.df", "view", "markdown", "page.width")
+  args_global = c("postprocess.tex", "postprocess.df", "view", "markdown", "page.width", "div.class")
   for(arg in setdiff(args_global, names(mc))){
     if(arg %in% names(opts)){
       assign(arg, opts[[arg]])
@@ -4585,7 +4585,7 @@ setFixest_etable = function(digits = 4, digits.stats = 5, fitstat,
                             style.df = NULL, notes = NULL, group = NULL, extralines = NULL,
                             fixef.group = NULL, placement = "htbp", drop.section = NULL,
                             view = FALSE, markdown = NULL, view.cache = FALSE,
-                            page.width = "fit",
+                            page.width = "fit", div.class = "etable",
                             postprocess.tex = NULL, postprocess.df = NULL,
                             fit_format = "__var__", meta.time = NULL,
                             meta.author = NULL, meta.sys = NULL,
@@ -4655,6 +4655,7 @@ setFixest_etable = function(digits = 4, digits.stats = 5, fitstat,
 
   check_arg(view, view.cache, "logical scalar")
   check_arg(markdown, "NULL scalar(logical, character)")
+  check_value(div.class, "character scalar")
 
   page.width = check_set_page_width(page.width)
 

--- a/R/etable.R
+++ b/R/etable.R
@@ -5406,7 +5406,7 @@ build_tex_png = function(x, view = FALSE, export = NULL, markdown = NULL,
   }
 
   if(!is.null(export)){
-    export_path = check_set_path(export, "w", up = up, recursive = TRUE)
+    export_path = check_set_path(export, "w, dir", create = TRUE, up = up, recursive = TRUE)
   }
 
   if(view || do_build){
@@ -5649,13 +5649,14 @@ build_tex_png = function(x, view = FALSE, export = NULL, markdown = NULL,
 }
 
 
-check_set_path = function(x, type = "", create = TRUE, up = 0){
+check_set_path = function(x, type = "", create = TRUE, up = 0, recursive = FALSE){
   # type:
   # + r: read (file or dir must exists), w (file is to be created)
   # + dir: directory and not a document
   # create:
   # - if file: creates the parent dir if the grand parent exists
   # - if dir: creates the dir only if grand parent exists
+  # - if recursive == TRUE: create all folders
 
   set_up(up + 1)
 
@@ -5696,12 +5697,18 @@ check_set_path = function(x, type = "", create = TRUE, up = 0){
   path_dir = str_trim(path, -nchar(file_name))
   if(nchar(path_dir) == 0) path_dir = "."
 
+  if(create & recursive) {
+    dir.create(path, recursive = TRUE)
+  }
+
   path_parent = dirname(path)
   if(dir.exists(path_parent)){
     if(is_dir && create){
       dir.create(path)
     }
-
+      
+    # ensure absolute path is returned for working with `tempdir()`
+    path = try(normalizePath(path, "/", mustWork = FALSE))
     return(path)
   }
 
@@ -5712,7 +5719,9 @@ check_set_path = function(x, type = "", create = TRUE, up = 0){
       if(is_dir){
         dir.create(path)
       }
-
+      
+      # ensure absolute path is returned for working with `tempdir()`
+      path = try(normalizePath(path, "/", mustWork = FALSE))
       return(path)
     }
   }

--- a/R/etable.R
+++ b/R/etable.R
@@ -5372,10 +5372,6 @@ build_tex_png = function(x, view = FALSE, export = NULL, markdown = NULL,
     }
   }
 
-  if(!is.null(export)){
-    export_path = check_set_path(export, "w", up = up)
-  }
-
   dir = NULL
   if(do_build){
 
@@ -5396,9 +5392,17 @@ build_tex_png = function(x, view = FALSE, export = NULL, markdown = NULL,
         time = gsub(" .+", "", Sys.time())
         png_name = .dsb("etable_tex_.[time]_.[id].png")
       }
+    } else if (!is.null(export) && grepl("^.+_|\\.png$", export)) {
+      # png name specified in export
+      png_name = basename(export)
+      export = dirname(export)
     } else {
       png_name = "etable.png"
     }
+  }
+
+  if(!is.null(export)){
+    export_path = check_set_path(export, "w", up = up, recursive = TRUE)
   }
 
   if(view || do_build){
@@ -5603,7 +5607,7 @@ build_tex_png = function(x, view = FALSE, export = NULL, markdown = NULL,
   if(view){
     my_viewer = getOption("viewer")
     if(is.null(my_viewer)){
-      warning("To preview the table, we need a viewer -- which wasn't found (it sjould work on RStudio and VScode).")
+      warning("To preview the table, we need a viewer -- which wasn't found (it should work on RStudio and VScode).")
     } else {
       # setting up the html document
 

--- a/R/etable.R
+++ b/R/etable.R
@@ -5720,8 +5720,6 @@ check_set_path = function(x, type = "", create = TRUE, up = 0){
 }
 
 viewer_html_template = function(png_name){
-  # I really wanted to see the full table all the time, so I had to add some JS.
-  # There must be some straightforward way in CSS, but I don't know it...
   .dsb0('
 <!DOCTYPE html>
 <html> <head>

--- a/R/etable.R
+++ b/R/etable.R
@@ -1174,7 +1174,10 @@ etable = function(..., vcov = NULL, stage = 2, agg = NULL,
 
     if(is_md){
       if(!knitr::is_latex_output()){
-        path = path_to_relative(path)
+        
+        orig = knitr::opts_knit$get("output.dir")
+        dest = normalizePath(path, "/", mustWork = FALSE)
+        path = path_to_relative(orig, dest)
         cat(sma('<div class = "{div.class}"><img src = "{path}"></div>\n'))
         return(invisible(NULL))
       }
@@ -7071,14 +7074,11 @@ is_Rmarkdown = function(){
   "knitr" %in% loadedNamespaces() && !is.null(knitr::pandoc_to())
 }
 
-path_to_relative = function(x){
+path_to_relative = function(orig, dest){
   # orig = "C:/Users/berge028/Google Drive/R_packages/fixest/fixest"
   # dest = "C:/Users/berge028/Google Drive/R_packages/automake/automake/NAMESPACE"
 
   # I'm not sure it works perfectly well on linux...
-
-  dest = normalizePath(x, "/", mustWork = FALSE)
-  orig = normalizePath(".", "/", mustWork = FALSE)
 
   if(dest == orig) return(".")
 

--- a/R/etable.R
+++ b/R/etable.R
@@ -1134,6 +1134,10 @@ etable = function(..., vcov = NULL, stage = 2, agg = NULL,
   # Export to file
   is_file = !missnull(file)
   if(is_file){
+    # Create directory if it doesn't exist
+    if(!DIR_EXISTS(dirname(file))){
+      dir.create(dirname(file), recursive = TRUE)
+    }
     error_sender(sink(file = file, append = !replace),
                  "Argument 'file': error when creating the document in ", file)
 

--- a/man/etable.Rd
+++ b/man/etable.Rd
@@ -232,6 +232,7 @@ setFixest_etable(
   markdown = NULL,
   view.cache = FALSE,
   page.width = "fit",
+  div.class = "etable",
   postprocess.tex = NULL,
   postprocess.df = NULL,
   fit_format = "__var__",


### PR DESCRIPTION
Hi Laurent,

This PR has a set of commits to (potentially) improve `etable`. Here's the set of changes:

1. `div.class` is an option for `setFixest_etable` to match `markdown`. 

2. `etable(..., file = path)` fails when `path` has a directory that doesn't exist. This PR checks for this and creates the directory if needed.

3. Fix a sort of nefarious bug with `export`. Say you have `etable(..., export = path)` where `path` is a relative directory, the directory does not exist, and `markdown = FALSE`. The function `check_set_path` will return the relative path back. However, building the png sets the working directory to `tempdir()`, so moving the png to `path` fails.

4. Allowing for named exports https://github.com/lrberge/fixest/issues/451
   
   To do this, the file name is extracted if it exists (and with the fix to 3) and used as `png_name`. 
   
5. The controversial change involves `markdown` processing. I can remove this one if you don't agree. 
   - Rmarkdown and quarto (both using knitr) saves `plot`s in `knitr::fig_path()` (usually `X_files/figures-html/`). Putting the etable pngs in here gives the benefit of allowing `self_contained` to process them. 
   - Quarto/`knitr` has the option `output.dir` which lets your execution working directory differ from where the output is created. You can access this with `knitr::opts_knit$get("output.dir")`. This means with this option, the images produced by `etable` won't be in the correct location of the `html` document.
   
     For example, if I have a .Rmd in a subfolder (e.g. `./vignettes/`) but I want it use the main folder (`./`) as the working directory, `etable` will use `./etable/images/` instead of `./vignettes/etable/images`. 

     By using these two functions, I think etable much better ties in with quarto/rmarkdown. I've faced this problem with my own day-to-day use of qmd, so it's not just a random edge case (or maybe I'm the edge case).