### PR TITLE
Add reference for VCOV after residualizing fixed-effects

### DIFF
--- a/R/VCOV.R
+++ b/R/VCOV.R
@@ -46,6 +46,10 @@
 #' @seealso
 #' See also the main estimation functions [`femlm`], [`feols`] or [`feglm`]. 
 #' [`summary.fixest`], [`confint.fixest`], [`resid.fixest`], [`predict.fixest`], [`fixef.fixest`].
+#' 
+#' @references
+#'
+#' Ding, Peng, 2021, "The Frisch–Waugh–Lovell theorem for standard errors." Statistics & Probability Letters 168. 
 #'
 #' @examples
 #'


### PR DESCRIPTION
Came across this paper that proves the vcov procedure after residualizing fixed effects and thought it would be nice to add to references: https://arxiv.org/pdf/2009.06621.pdf