### PR TITLE
Escape latex in fit statistics aliases in `esttex()`, fixes #505

### DIFF
--- a/R/etable.R
+++ b/R/etable.R
@@ -2857,15 +2857,20 @@ results2formattedList = function(dots, vcov = NULL, ssc = getFixest_ssc(), stage
 
       # Now the aliases
       fitstat_dict_new = c()
-      fun_rename = function(x) {
+      fun_rename = function(x, isTex) {
         if(!grepl("::", x, fixed = TRUE)) return(fitstat_dict[x])
 
         xx = strsplit(x, "::")[[1]]
+
+        if(isTex) {
+          xx[2] = escape_latex(xx[2])
+        }
+
         paste0(fitstat_dict[xx[1]], ", ", dict_apply(xx[2], dict))
       }
 
       for(v in all_names_new){
-        fitstat_dict_new[v] = fun_rename(v)
+        fitstat_dict_new[v] = fun_rename(v, isTex)
       }
 
       fitstat_list = fitstat_list_new


### PR DESCRIPTION
Fix the issue #505 by escaping special characters in the fit statistics aliases when exporting the results to latex with `esttex()` or `esttable()`.

The previous tests still pass.

Here is a simple test that did not pass before:
```R
N <- 1000

df <- data.frame(
    z = runif(N),
    e1 = rnorm(N),
    e2 = rnorm(N)
)

df$x_ <- 1 + 2 * df$z + df$e1
df$y <- 3 + 4 * df$x + df$e2

temp_dir <- tempdir()
temp_file <- paste0(temp_dir, "/test_tex_escape.png")

results <- fixest::feols(y ~ 1 | x_ ~ z, data = df)

fixest::esttex(results, fitstat = "ivf", export = temp_file)

file.remove(temp_file)
```