### PR TITLE
Fixes for KP stat calculation

### DIFF
--- a/tests/fixest_tests.R
+++ b/tests/fixest_tests.R
@@ -2972,6 +2972,7 @@ base$cl_var = rep(1:50, 3) # using `fe` to cluster causes a vcov PSD warning
 est_iv = feols(y ~ x1 | x_endo_1 + x_endo_2 ~ x_inst_1 + x_inst_2, base)
 
 fitstat(est_iv, ~ f + ivf + ivf2 + wald + ivwald + ivwald2 + wh + sargan + kpr + rmse + g + n + ll + sq.cor + r2)
+test(c(length(est_iv$iv_first_stage), est_iv$iv_n_inst), c(2, 2)) # kpr relies on accessing these
 
 est_iv_uneven = feols(y ~ x1 | x_endo_1 ~ x_inst_1 + x_inst_2, base, cluster = "cl_var")
 fitstat(est_iv_uneven, ~ f + ivf + ivf2 + wald + ivwald + ivwald2 + wh + sargan + kpr + rmse + g + n + ll + sq.cor + r2)


### PR DESCRIPTION
Fixes #607 

- This PR fixes the error `Error in solve(t(Gmat)) %*% PI` by ensuring `PI` is a matrix rather than a dataframe (as mentioned in https://github.com/lrberge/fixest/issues/161#issuecomment-2295394990)
- It adds a warning for the case with clustering and n_endo ≠ n_inst, but doesn't implement the functionality. The code now returns an `NA` value for that case.
- It adds a couple of tests that run these cases and updates the URL for https://github.com/FixedEffects/Vcov.jl