### PR TITLE
Do not warn in `update.*()` functions if `use_calling_env` is passed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 
 - fix bug leading to R crach when the dependent variable contained only missing values (reported by @Orgron, #603)
 
+- `update.fixest()` and `update.fixest_multi()` no longer throw a warning if `use_calling_env` is used (#619, @etiennebacher).
+
 # fixest 0.13.2
 
 ## Bug fixes

--- a/R/methods.R
+++ b/R/methods.R
@@ -3250,7 +3250,7 @@ update.fixest = function(object, fml.update = NULL, fml = NULL, nframes = 1,
 
   # new call: call_clear
   call_clear = call_old
-  for(arg in setdiff(names(call_new)[-1], c("fml.update", "nframes", "evaluate", "object"))){
+  for(arg in setdiff(names(call_new)[-1], c("fml.update", "nframes", "evaluate", "object", "use_calling_env"))){
     if(is.null(call_new[[arg]])){
       # for some raeson, it wouldn't work if call_new[[arg]] is NULL
       call_clear[[arg]] = NULL

--- a/tests/fixest_tests.R
+++ b/tests/fixest_tests.R
@@ -2825,6 +2825,19 @@ est_clu = update(est, vcov = ~species)
 est_clu = feols(y ~ x1 | species, base)
 test(se(est_add_fe), se(est_add_fe_noup))
 
+# No warnings when using use_calling_env = FALSE
+# https://github.com/lrberge/fixest/issues/618
+est_to_update = feols(mpg ~ hp, data = mtcars)
+update_is_silent <- tryCatch(
+  {
+    update(est_to_update, data = mtcars, use_calling_env = FALSE)
+    TRUE 
+  },
+  error = function(e) FALSE,
+  warning = function(e) FALSE
+)
+test(update_is_silent, TRUE)
+
 #
 # FE estimation
 #


### PR DESCRIPTION
Fixes #618 