### PR TITLE
Fix iplot parsing for IV sunab terms

### DIFF
--- a/R/coefplot.R
+++ b/R/coefplot.R
@@ -2089,7 +2089,24 @@ coefplot_prms = function(all_models, vcov = NULL, se, ci_low, ci_high, x, x.shif
       # avoids bug with IVs => problem if user names the variables that way
       is_IV = FALSE
       if(isTRUE(object$iv) && identical(object$iv_stage, 2)){
-        all_vars = gsub("^fit_", "", all_vars)
+        iv_fit_names = object[["iv_endo_names_fit"]]
+        if(is.character(iv_fit_names) && length(iv_fit_names) > 0){
+          # Restrict renaming to fitted endogenous terms only.
+          # This avoids altering user variables that simply start with "fit_".
+          is_fit = all_vars %in% iv_fit_names
+          if(any(is_fit)){
+            all_vars_fit = all_vars[is_fit]
+            # fit_x:var -> var (single ':'), but keep names like fit_user::2 unchanged here.
+            all_vars_fit = sub("^fit_[^:]+:(?!:)", "", all_vars_fit, perl = TRUE)
+            # For fitted terms still starting with fit_ (e.g. fit_x2::2), remove the prefix.
+            all_vars_fit = sub("^fit_", "", all_vars_fit)
+            all_vars[is_fit] = all_vars_fit
+          }
+        } else {
+          # Legacy fallback for old objects without iv_endo_names_fit.
+          all_vars = sub("^fit_[^:]+:(?!:)", "", all_vars, perl = TRUE)
+          all_vars = sub("^fit_", "", all_vars)
+        }
         names(estimate) = all_vars
       }
 
@@ -2852,8 +2869,6 @@ setFixest_coefplot = function(style, horiz = FALSE, dict = getFixest_dict(), kee
 getFixest_coefplot = function(){
   getOption("fixest_coefplot")
 }
-
-
 
 
 

--- a/tests/fixest_tests.R
+++ b/tests/fixest_tests.R
@@ -2000,6 +2000,35 @@ res_sunab = feols(y ~ x1 + sunab(year_treated, year, bin.rel = "bin::2"), base_s
 iplot(res_sunab)
 test(length(coef(res_sunab)), 12)
 
+# IV + sunab + interacted fitted regressor
+set.seed(20260213)
+n_id = 200L
+never_cohort = 100L
+dt_sunab_iv = expand.grid(id = 1:n_id, rel_time = -2:2)
+dt_sunab_iv$high_growth = as.integer(dt_sunab_iv$id <= n_id / 2L)
+dt_sunab_iv$cohort = ifelse(dt_sunab_iv$high_growth == 1L, 0L, never_cohort)
+dt_sunab_iv$x = rnorm(nrow(dt_sunab_iv))
+dt_sunab_iv$id_fe = rnorm(n_id)[dt_sunab_iv$id]
+dt_sunab_iv$y = 0.08 * dt_sunab_iv$x * (dt_sunab_iv$rel_time >= 0L) * dt_sunab_iv$high_growth + dt_sunab_iv$id_fe + rnorm(nrow(dt_sunab_iv), sd = 0.25)
+
+res_sunab_iv = feols(y ~ 1 | x:sunab(cohort, rel_time, ref.p = -1, ref.c = never_cohort, no_agg = TRUE) ~ sunab(cohort, rel_time, ref.p = -1, ref.c = never_cohort, no_agg = TRUE), dt_sunab_iv)
+iv_sunab_iplot_ok = tryCatch({
+  iplot(res_sunab_iv)
+  TRUE
+}, error = function(e) FALSE)
+test(iv_sunab_iplot_ok, TRUE)
+
+# IV with an exogenous i() variable whose name starts with "fit_"
+set.seed(1)
+base$fit_user = sample(1:3, nrow(base), TRUE)
+res_iv_fit_user = feols(y ~ i(fit_user) | x2 ~ x3, base)
+iv_fit_user_iplot_ok = tryCatch({
+  iplot(res_iv_fit_user)
+  TRUE
+}, error = function(e) FALSE)
+test(iv_fit_user_iplot_ok, TRUE)
+base$fit_user = NULL
+
 
 ####
 #### bin ####
@@ -3173,11 +3202,6 @@ est_mult = feols(y ~ x1 + x2, base, split = ~species)
 test(dim(fixest_data(est_mult)), dim(base))
 
 test(nrow(fixest_data(est_mult, "esti")), 45)
-
-
-
-
-
 
 
 


### PR DESCRIPTION
`iplot()` errors on valid IV models that use `sunab(..., no_agg = TRUE)` in an interacted endogenous term, even though the coefficient names are valid and plottable.

On the econometrics side, you may argue that Sun & Abraham do not cover fuzzy designs, so this is working as intended as we don't know what the Wald-DiD estimator yields under staggered treatments (do we? maybe under homogeneous effects but staggered treatments?). But then I think it should at least output a clearer error like the "without a doubt, your model is misspecified" when you have only variables that are colinear with the FEs. I may do that if you want. 

## Repro

```r
library(data.table)
library(fixest)

set.seed(20260213L)
n_id <- 400L
never_cohort <- 100L

dt <- CJ(id = 1:n_id, rel_time = -2:2)
dt[, high_growth := as.integer(id <= n_id / 2L)]
dt[, cohort := fifelse(high_growth == 1L, 0L, never_cohort)]
dt[, x := rnorm(.N)]
dt[, id_fe := rnorm(n_id)[id]]
dt[, y := 0.08 * x * (rel_time >= 0L) * high_growth + id_fe + rnorm(.N, sd = 0.25)]

iv_model <- feols(
  y ~ 1 |
    x:sunab(cohort, rel_time, ref.p = -1, ref.c = never_cohort, no_agg = TRUE) ~
    sunab(cohort, rel_time, ref.p = -1, ref.c = never_cohort, no_agg = TRUE),
  data = dt
)

iplot(iv_model)
```

## Actual behavior

iplot() throws:

> In iplot(), no valid variable created with i() found...

## Expected behavior

iplot() should plot the IV sunab coefficient

## Root cause
In IV stage 2, `iplot()` used broad `fit_` prefix stripping, which would fail to recover the correct `i()/sunab` term names.

I think there was an issue in the past with this (which maybe I reported myself? not sure), so I was extra cautious in stripping only actual endogenous variables that were fitted in the first stage. 

## Fix
- Restrict renaming to known fitted endogenous names via `object$iv_endo_names_fit`.
- Strip only the fitted-endo interaction prefix (`fit_<endo>:`) where appropriate.
- Keep a fallback path for legacy objects without `iv_endo_names_fit`.

## Tests
Added regression coverage in `tests/fixest_tests.R`:
1. IV + `sunab(..., no_agg = TRUE)` interacted fitted regressor now works with `iplot()`.
2. IV with an exogenous `i()` variable named with `fit_` prefix (e.g. `fit_user`) still works, preventing over-matching regressions.

## Verification
- Targeted test chunk (`Interact`) passes.
- Repro script now reports `IV iplot: OK`.

## Disclaimer

I noticed the error while writing code for a WP and thought it'd be pretty easy to fix. I had Codex write the correction, and it just changed the regex, but I was suspicious so I probed it a bit more and found the issue with variables that start with "fit_", so I had it make the code robust to that as well. Tests pass, I have experience with R and the code smells okay to me, but let me know if you want me to check more thoroughly something specific. 