### PR TITLE
Fix typos in vcov docs and oldargs_to_vcov code bug

### DIFF
--- a/R/VCOV.R
+++ b/R/VCOV.R
@@ -73,8 +73,7 @@
 #' #
 #' # Heteroskedasticity-robust VCOV
 #' #
-#'
-#' # By default the VCOV assumes iid errors:
+#' # Heteroskedasticity-robust (White) standard errors:
 #' se(vcov(est, "hetero"))
 #'
 #' # => note that it also accepts vcov = "White" and vcov = "HC1" as aliases.
@@ -155,7 +154,7 @@
 #'
 #' est_panel = feols(y ~ x1, base_did, panel.id = ~id + period)
 #'
-#' # Both methods, NM and DK, now work automatically
+#' # Both methods, NW and DK, now work automatically
 #' se(vcov(est_panel, "NW"))
 #' se(vcov(est_panel, "DK"))
 #'
@@ -176,7 +175,7 @@
 #'
 #' # Alternative way:
 #'
-#' # -> using the vcov_DK function
+#' # -> using the vcov_conley function
 #' se(vcov(est_geo, vcov_conley(lat = "lat", lon = "long", cutoff = 100)))
 #'
 #' # -------------------|
@@ -184,7 +183,7 @@
 #' # -------------------|
 #' # By default the latitude and longitude are directly fetched in the data based
 #' # on pattern matching. So you don't have to specify them.
-#' # Furhter, an automatic cutoff is deduced by default.
+#' # Further, an automatic cutoff is deduced by default.
 #'
 #' # The following works:
 #' se(vcov(est_geo, "conley"))
@@ -1150,13 +1149,13 @@ ssc = function(K.adj = TRUE, K.fixef = "nonnested", K.exact = FALSE,
 #' @param ssc An object returned by the function [`ssc`]. It specifies how to perform the small 
 #' sample correction. Note that this argument is only used in `"HC1"` which accepts 
 #' ssc arguments starting with `"K"`. In that case when `ssc(K.adj = FALSE)`, 
-#' it leads to "HC0". The argument `ssc` is ignored for `HC2` and `HC2` VCOVs.
+#' it leads to "HC0". The argument `ssc` is ignored for `HC2` and `HC3` VCOVs.
 #'
 #' @section Small sample correction:
 #' A custom small sample correction can be applied to the HC1 VCOV using the [`ssc`] argument 
 #' and function. By default an adjustment of N/(N-K) is applied to the VCOV, with N the number of
 #' observations and K the number of parameters. If `ssc(K.adj = FALSE)`, meaning that there is 
-#' no adjustment, this leads to the HC0 VCOV. Finally ssc's arguemnts
+#' no adjustment, this leads to the HC0 VCOV. Finally ssc's arguments
 #' K.fixef and K.exact determine how to account for the parameters associated to the fixed-effects 
 #' (if the estimation contains fixed-effects).
 #' 
@@ -2452,7 +2451,7 @@ oldargs_to_vcov = function(se, cluster, vcov){
   if(missnull(cluster)){
     vcov = se
 
-  } else if(!se %in% c("cluster", "twoway", "threeway", "frouway")){
+  } else if(!se %in% c("cluster", "twoway", "threeway", "fourway")){
     stop_up("The VCOV requested with the argument se = '", se, "' is not compatible with the use of the argument 'cluster' (i.e. you have to choose!).")
 
   } else {
@@ -3105,7 +3104,7 @@ getFixest_ssc = function(vcov_name = NULL){
 #' `"twoway"`. The type of standard-errors to use by default for estimations with *two or more* 
 #' fixed-effects.
 #' @param panel Character scalar equal to either: `"iid"` (default), `"hetero"`, `"cluster"`, or 
-#' `"driscoll_kraaay"`. The type of standard-errors to use by default for estimations with the 
+#' `"driscoll_kraay"`. The type of standard-errors to use by default for estimations with the 
 #' argument `panel.id` set up. Note that panel has precedence over the presence of fixed-effects.
 #' @param all Character scalar equal to either: `"iid"`, or `"hetero"` (or `"cluster"` if 
 #' the argument `no_FE` is provided). 

--- a/R/methods.R
+++ b/R/methods.R
@@ -497,7 +497,7 @@ print.fixest = function(x, n, type = "table", fitstat = NULL, ...){
 #'
 #' est_panel = feols(y ~ x1, base_did, panel.id = ~id + period)
 #'
-#' # Both methods, NM and DK, now work automatically
+#' # Both methods, NW and DK, now work automatically
 #' summary(est_panel, "NW")
 #' summary(est_panel, "DK")
 #'

--- a/man/fixest-package.Rd
+++ b/man/fixest-package.Rd
@@ -54,6 +54,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Laurent Berge \email{laurent.berge@u-bordeaux.fr}
 
+Authors:
+\itemize{
+  \item Laurent Berge \email{laurent.berge@u-bordeaux.fr}
+}
+
 Other contributors:
 \itemize{
   \item Sebastian Krantz [contributor]

--- a/man/setFixest_vcov.Rd
+++ b/man/setFixest_vcov.Rd
@@ -28,7 +28,7 @@ The type of standard-errors to use by default for estimations with \emph{one} fi
 fixed-effects.}
 
 \item{panel}{Character scalar equal to either: \code{"iid"} (default), \code{"hetero"}, \code{"cluster"}, or
-\code{"driscoll_kraaay"}. The type of standard-errors to use by default for estimations with the
+\code{"driscoll_kraay"}. The type of standard-errors to use by default for estimations with the
 argument \code{panel.id} set up. Note that panel has precedence over the presence of fixed-effects.}
 
 \item{all}{Character scalar equal to either: \code{"iid"}, or \code{"hetero"} (or \code{"cluster"} if

--- a/man/summary.fixest.Rd
+++ b/man/summary.fixest.Rd
@@ -199,7 +199,7 @@ summary(est, DK(3) ~ period)
 
 est_panel = feols(y ~ x1, base_did, panel.id = ~id + period)
 
-# Both methods, NM and DK, now work automatically
+# Both methods, NW and DK, now work automatically
 summary(est_panel, "NW")
 summary(est_panel, "DK")
 

--- a/man/vcov.fixest.Rd
+++ b/man/vcov.fixest.Rd
@@ -124,8 +124,7 @@ se(vcov(est, "iid"))
 #
 # Heteroskedasticity-robust VCOV
 #
-
-# By default the VCOV assumes iid errors:
+# Heteroskedasticity-robust (White) standard errors:
 se(vcov(est, "hetero"))
 
 # => note that it also accepts vcov = "White" and vcov = "HC1" as aliases.
@@ -206,7 +205,7 @@ se(vcov(est, vcov_DK(time = "period", lag = 3)))
 
 est_panel = feols(y ~ x1, base_did, panel.id = ~id + period)
 
-# Both methods, NM and DK, now work automatically
+# Both methods, NW and DK, now work automatically
 se(vcov(est_panel, "NW"))
 se(vcov(est_panel, "DK"))
 
@@ -227,7 +226,7 @@ se(vcov(est_geo, conley(100) ~ lat + long))
 
 # Alternative way:
 
-# -> using the vcov_DK function
+# -> using the vcov_conley function
 se(vcov(est_geo, vcov_conley(lat = "lat", lon = "long", cutoff = 100)))
 
 # -------------------|
@@ -235,7 +234,7 @@ se(vcov(est_geo, vcov_conley(lat = "lat", lon = "long", cutoff = 100)))
 # -------------------|
 # By default the latitude and longitude are directly fetched in the data based
 # on pattern matching. So you don't have to specify them.
-# Furhter, an automatic cutoff is deduced by default.
+# Further, an automatic cutoff is deduced by default.
 
 # The following works:
 se(vcov(est_geo, "conley"))

--- a/man/vcov_hetero.Rd
+++ b/man/vcov_hetero.Rd
@@ -26,7 +26,7 @@ Note that the case is ignored.}
 \item{ssc}{An object returned by the function \code{\link{ssc}}. It specifies how to perform the small
 sample correction. Note that this argument is only used in \code{"HC1"} which accepts
 ssc arguments starting with \code{"K"}. In that case when \code{ssc(K.adj = FALSE)},
-it leads to "HC0". The argument \code{ssc} is ignored for \code{HC2} and \code{HC2} VCOVs.}
+it leads to "HC0". The argument \code{ssc} is ignored for \code{HC2} and \code{HC3} VCOVs.}
 
 \item{vcov_fix}{Logical scalar, default is \code{FALSE}. If the VCOV ends up not being
 positive definite, whether to "fix" it using an eigenvalue decomposition
@@ -55,7 +55,7 @@ Computes the heteroskedasticity-robust VCOV of \code{fixest} objects.
 A custom small sample correction can be applied to the HC1 VCOV using the \code{\link{ssc}} argument
 and function. By default an adjustment of N/(N-K) is applied to the VCOV, with N the number of
 observations and K the number of parameters. If \code{ssc(K.adj = FALSE)}, meaning that there is
-no adjustment, this leads to the HC0 VCOV. Finally ssc's arguemnts
+no adjustment, this leads to the HC0 VCOV. Finally ssc's arguments
 K.fixef and K.exact determine how to account for the parameters associated to the fixed-effects
 (if the estimation contains fixed-effects).
 }

--- a/vignettes/standard_errors.Rmd
+++ b/vignettes/standard_errors.Rmd
@@ -53,7 +53,7 @@ summary(gravity, vcov = "twoway", ssc = ssc(K.adj = FALSE, G.adj = FALSE))
 
 The argument `vcov` can be equal to either: `"iid"`, `"hetero"`, `"cluster"`, `"twoway"`, `"NW"`, `"DK"`, or `"conley"`.
 
-If `vcov = "iid"`, then the standard-errors are based on the assumption that the errors are non correlated and homoskedastic. If `vcov = "hetero"`, this corresponds to the classic hereoskedasticity-robust standard-errors (White correction), where it is assumed that the errors are non correlated but the variance of their generative law may vary. 
+If `vcov = "iid"`, then the standard-errors are based on the assumption that the errors are non correlated and homoskedastic. If `vcov = "hetero"`, this corresponds to the classic heteroskedasticity-robust standard-errors (White correction), where it is assumed that the errors are non correlated but the variance of their generative law may vary. 
 
 If `vcov = "cluster"`, then arbitrary correlation of the errors within clusters is accounted for. Same for `vcov = "twoway"`: arbitrary correlation within each of the two clusters is accounted for. 
 


### PR DESCRIPTION
## Summary

Fixes several typos in `R/VCOV.R` documentation and one code bug in `oldargs_to_vcov()`.

### Code bug fix

**`oldargs_to_vcov()` at line 2454**: The guard clause checked for `"frouway"` (misspelled) instead of `"fourway"`. This meant that if a user passed `se = "fourway"` with a `cluster` argument using the deprecated `se` interface, the guard would fail to match and produce a confusing error instead of constructing the fourway-clustered VCOV. The correct spelling `"fourway"` is used everywhere else in the codebase (lines 1833, 1838, 1839, 1933, and in `methods.R:373`).

### Documentation fixes

| Location | Before | After |
|----------|--------|-------|
| `vcov_hetero` roxygen (line 1152) | `HC2` and `HC2` | `HC2` and `HC3` |
| `vcov_hetero` roxygen (line 1158) | `arguemnts` | `arguments` |
| `setFixest_vcov` roxygen (line 3107) | `driscoll_kraaay` | `driscoll_kraay` |
| `vcov.fixest` examples (line 158) | `NM and DK` | `NW and DK` |
| `vcov.fixest` examples (line 179) | `vcov_DK function` | `vcov_conley function` |
| `vcov.fixest` examples (line 187) | `Furhter` | `Further` |
| `standard_errors.Rmd` vignette | `hereoskedasticity` | `heteroskedasticity` |

### Validation

- `R CMD build` succeeds
- `R CMD check --no-manual --no-vignettes` passes (1 pre-existing NOTE about Makevars, unrelated)
- Man pages regenerated via `roxygen2::roxygenise()`

### Files changed

- `R/VCOV.R` — 4 targeted typo fixes + 3 example comment fixes
- `R/methods.R` — 1 comment fix (NM → NW)
- `vignettes/standard_errors.Rmd` — 1 typo fix
- `man/setFixest_vcov.Rd`, `man/vcov_hetero.Rd`, `man/vcov.fixest.Rd`, `man/summary.fixest.Rd`, `man/fixest-package.Rd` — regenerated from roxygen