### PR TITLE
Include 'ferols' as family in etable()

### DIFF
--- a/R/etable.R
+++ b/R/etable.R
@@ -2674,6 +2674,14 @@ results2formattedList = function(dots, vcov = NULL, ssc = NULL, stage = 2,
       fam = "Poisson"
     } else if(x$method == "fenegbin"){
       fam = "Neg. Bin."
+    } else if(x$method == "ferols") {
+        cap <- function(x) {
+            paste0(toupper(substr(x, 1, 1)), substring(x, 2))
+        }
+        fam = paste0(
+            "Robust M (", cap(x$robust$family), " ",
+            round(100*x$robust$efficiency), "% efficiency)"
+        )
     }
     family_list[[m]] = fam
 


### PR DESCRIPTION
[Second attempt as previous PR was flooded by automated whitespace edits - sorry!]

Hi there:

This small patch adds [`ferols`](https://github.com/joachim-gassen/ferols) as a a recognised method to the `etable()` family recognition. I fixes joachim-gassen/ferols#2 but I am not sure whether you want to support outside models in your codebase. So, by all means, feel free to reject/ignore.

Another thing. Given how sensitive robust regression is to parameter choices like loss functions and efficiency levels, I decided to add these to the family string, making it rather verbose and long. I see that this is at odds with the other strings, so an obvious alternative would be to simply use "Robust M" as a family. 

Thank you for considering and again for the awesome `fixest` package.