### PR TITLE
fix: correct K.fixef comments in ssc() examples from FALSE/TRUE to "none"/"full"

### DIFF
--- a/R/VCOV.R
+++ b/R/VCOV.R
@@ -1070,19 +1070,19 @@ vcov.fixest = function(object, vcov = NULL, se = NULL, cluster, ssc = NULL, attr
 #' attributes(vcov(est, attr = TRUE))[c("ssc", "df.K")]
 #'
 #'
-#' # K.fixef = FALSE
+#' # K.fixef = "none"
 #' #  => adjustment K = 1 (i.e. only x)
 #' summary(est, ssc = ssc(K.fixef = "none"))
 #' attr(vcov(est, ssc = ssc(K.fixef = "none"), attr = TRUE), "df.K")
 #'
 #'
-#' # K.fixef = TRUE
+#' # K.fixef = "full"
 #' #  => adjustment K = 1 + 3 + 5 - 1 (i.e. x + fe1 + fe2 - 1 restriction)
 #' summary(est, ssc = ssc(K.fixef = "full"))
 #' attr(vcov(est, ssc = ssc(K.fixef = "full"), attr = TRUE), "df.K")
 #'
 #'
-#' # K.fixef = TRUE & K.exact = TRUE
+#' # K.fixef = "full" & K.exact = TRUE
 #' #  => adjustment K = 1 + 3 + 5 - 2 (i.e. x + fe1 + fe2 - 2 restrictions)
 #' summary(est, ssc = ssc(K.fixef = "full", K.exact = TRUE))
 #' attr(vcov(est, ssc = ssc(K.fixef = "full", K.exact = TRUE), attr = TRUE), "df.K")

--- a/man/ssc.Rd
+++ b/man/ssc.Rd
@@ -124,19 +124,19 @@ summary(est)
 attributes(vcov(est, attr = TRUE))[c("ssc", "df.K")]
 
 
-# K.fixef = FALSE
+# K.fixef = "none"
 #  => adjustment K = 1 (i.e. only x)
 summary(est, ssc = ssc(K.fixef = "none"))
 attr(vcov(est, ssc = ssc(K.fixef = "none"), attr = TRUE), "df.K")
 
 
-# K.fixef = TRUE
+# K.fixef = "full"
 #  => adjustment K = 1 + 3 + 5 - 1 (i.e. x + fe1 + fe2 - 1 restriction)
 summary(est, ssc = ssc(K.fixef = "full"))
 attr(vcov(est, ssc = ssc(K.fixef = "full"), attr = TRUE), "df.K")
 
 
-# K.fixef = TRUE & K.exact = TRUE
+# K.fixef = "full" & K.exact = TRUE
 #  => adjustment K = 1 + 3 + 5 - 2 (i.e. x + fe1 + fe2 - 2 restrictions)
 summary(est, ssc = ssc(K.fixef = "full", K.exact = TRUE))
 attr(vcov(est, ssc = ssc(K.fixef = "full", K.exact = TRUE), attr = TRUE), "df.K")


### PR DESCRIPTION
## Summary

The `ssc()` examples in `R/VCOV.R` had misleading comments saying `K.fixef = FALSE` and `K.fixef = TRUE` when the parameter actually accepts character values (`"none"`, `"full"`, `"nonnested"`), not logical values. This could confuse users into thinking `K.fixef` accepts logical arguments.

### Changes

| Location | Before | After |
|----------|--------|-------|
| `R/VCOV.R:1073` | `# K.fixef = FALSE` | `# K.fixef = "none"` |
| `R/VCOV.R:1079` | `# K.fixef = TRUE` | `# K.fixef = "full"` |
| `R/VCOV.R:1085` | `# K.fixef = TRUE & K.exact = TRUE` | `# K.fixef = "full" & K.exact = TRUE` |
| `man/ssc.Rd` | Regenerated from roxygen | |

### Context

The `K.fixef` parameter of `ssc()` is documented as accepting character scalars (`"none"`, `"full"`, `"nonnested"`), but the example comments used logical values (FALSE/TRUE), which is inconsistent with the parameter's actual type signature. The code itself (the actual `ssc()` calls) was already correct.

### Validation

- `R CMD build .` — Success
- `R CMD check --no-manual --no-vignettes` — Pass (1 pre-existing NOTE about Makevars, unrelated)
- `roxygen2::roxygenise()` — Regenerated `man/ssc.Rd` successfully
- No overlap with PR #654 or #656 (which fix different typos in VCOV.R)