### PR TITLE
fix: vcov_fix default docs FALSE->TRUE, typos in roxygen (greated, Furhter, occurence)

### DIFF
--- a/R/VCOV.R
+++ b/R/VCOV.R
@@ -184,7 +184,7 @@
 #' # -------------------|
 #' # By default the latitude and longitude are directly fetched in the data based
 #' # on pattern matching. So you don't have to specify them.
-#' # Furhter, an automatic cutoff is deduced by default.
+#' # Further, an automatic cutoff is deduced by default.
 #'
 #' # The following works:
 #' se(vcov(est_geo, "conley"))

--- a/R/methods.R
+++ b/R/methods.R
@@ -4446,7 +4446,7 @@ hatvalues.fixest = function(model, exact = TRUE, boot.size = 1000, ...){
   
   mats$fixef = sparse_model_matrix(model, type = "fixef", collin.rm = TRUE, sortCols = FALSE)
 
-  # Check for slope.vars and move to seperate matrix
+  # Check for slope.vars and move to separate matrix
   if (!is.null(model$slope_flag)) {
     slope_var_cols = which(
       grepl("\\[\\[", colnames(mats$fixef))

--- a/R/methods.R
+++ b/R/methods.R
@@ -406,7 +406,7 @@ print.fixest = function(x, n, type = "table", fitstat = NULL, ...){
 #' coefficients only.) Logical, default is `FALSE`. If `TRUE`, then the bounded coefficients 
 #' (if any) are treated as unrestricted coefficients and their S.E. is computed (otherwise 
 #' it is not).
-#' @param vcov_fix Logical scalar, default is `FALSE`. If the VCOV ends up not being 
+#' @param vcov_fix Logical scalar, default is `TRUE`. If the VCOV ends up not being 
 #' positive definite, whether to "fix" it using an eigenvalue decomposition 
 #' (a la Cameron, Gelbach & Miller 2011).
 #' Since the VCOV should be PSD asymptotically, this might be a sign of a problem 
@@ -414,7 +414,7 @@ print.fixest = function(x, n, type = "table", fitstat = NULL, ...){
 #' If a problem is detected, the function will print a message to inform you. 
 #' Note that a message informs the user **only if** the regularized PD matrix is 
 #' substantially different than the original non PD one (i.e. at least one difference
-#' between the two greated than 1e-8).
+#' between the two greater than 1e-8).
 #' @param n Integer, default is 1000. Number of coefficients to display when the print method 
 #' is used.
 #' @param ... Only used if the argument `vcov` is provided and is a function: extra arguments 

--- a/R/panel.R
+++ b/R/panel.R
@@ -577,7 +577,7 @@ d__expand = function(x, k = 1, fill){
 #' try(lag(x~id+time, 1, base_dup))
 #'
 #'
-#' # Error is bypassed, lag corresponds to first occurence of (id, time)
+#' # Error is bypassed, lag corresponds to first occurrence of (id, time)
 #' lag(x~id+time, 1, base_dup, duplicate.method = "first")
 #'
 #'

--- a/man/fixest-package.Rd
+++ b/man/fixest-package.Rd
@@ -54,6 +54,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Laurent Berge \email{laurent.berge@u-bordeaux.fr}
 
+Authors:
+\itemize{
+  \item Laurent Berge \email{laurent.berge@u-bordeaux.fr}
+}
+
 Other contributors:
 \itemize{
   \item Sebastian Krantz [contributor]

--- a/man/lag.formula.Rd
+++ b/man/lag.formula.Rd
@@ -95,7 +95,7 @@ base_dup = data.frame(id = rep(1:2, each = 4),
 try(lag(x~id+time, 1, base_dup))
 
 
-# Error is bypassed, lag corresponds to first occurence of (id, time)
+# Error is bypassed, lag corresponds to first occurrence of (id, time)
 lag(x~id+time, 1, base_dup, duplicate.method = "first")
 
 

--- a/man/summary.fixest.Rd
+++ b/man/summary.fixest.Rd
@@ -104,7 +104,7 @@ it is not).}
 \item{n}{Integer, default is 1000. Number of coefficients to display when the print method
 is used.}
 
-\item{vcov_fix}{Logical scalar, default is \code{FALSE}. If the VCOV ends up not being
+\item{vcov_fix}{Logical scalar, default is \code{TRUE}. If the VCOV ends up not being
 positive definite, whether to "fix" it using an eigenvalue decomposition
 (a la Cameron, Gelbach & Miller 2011).
 Since the VCOV should be PSD asymptotically, this might be a sign of a problem
@@ -112,7 +112,7 @@ with using the asymptotic approximation (e.g. too few units in clusters).
 If a problem is detected, the function will print a message to inform you.
 Note that a message informs the user \strong{only if} the regularized PD matrix is
 substantially different than the original non PD one (i.e. at least one difference
-between the two greated than 1e-8).}
+between the two greater than 1e-8).}
 
 \item{nthreads}{The number of threads. Can be: a) an integer lower than, or equal to,
 the maximum number of threads; b) 0: meaning all available threads will be used;

--- a/man/vcov.fixest.Rd
+++ b/man/vcov.fixest.Rd
@@ -74,7 +74,7 @@ c) a number strictly between 0 and 1 which represents the fraction of all thread
 The default is to use 50\% of all threads. You can set permanently the number
 of threads used within this package using the function \code{\link{setFixest_nthreads}}.}
 
-\item{vcov_fix}{Logical scalar, default is \code{FALSE}. If the VCOV ends up not being
+\item{vcov_fix}{Logical scalar, default is \code{TRUE}. If the VCOV ends up not being
 positive definite, whether to "fix" it using an eigenvalue decomposition
 (a la Cameron, Gelbach & Miller 2011).
 Since the VCOV should be PSD asymptotically, this might be a sign of a problem
@@ -82,7 +82,7 @@ with using the asymptotic approximation (e.g. too few units in clusters).
 If a problem is detected, the function will print a message to inform you.
 Note that a message informs the user \strong{only if} the regularized PD matrix is
 substantially different than the original non PD one (i.e. at least one difference
-between the two greated than 1e-8).}
+between the two greater than 1e-8).}
 
 \item{...}{Other arguments to be passed to \code{\link{summary.fixest}}.
 

--- a/man/vcov.fixest.Rd
+++ b/man/vcov.fixest.Rd
@@ -235,7 +235,7 @@ se(vcov(est_geo, vcov_conley(lat = "lat", lon = "long", cutoff = 100)))
 # -------------------|
 # By default the latitude and longitude are directly fetched in the data based
 # on pattern matching. So you don't have to specify them.
-# Furhter, an automatic cutoff is deduced by default.
+# Further, an automatic cutoff is deduced by default.
 
 # The following works:
 se(vcov(est_geo, "conley"))

--- a/man/vcov_cluster.Rd
+++ b/man/vcov_cluster.Rd
@@ -17,7 +17,7 @@ data set used for the estimation.}
 \item{ssc}{An object returned by the function \code{\link{ssc}}. It specifies how to perform the small
 sample correction. These VCOVs accept all the arguments of \code{\link{ssc}}.}
 
-\item{vcov_fix}{Logical scalar, default is \code{FALSE}. If the VCOV ends up not being
+\item{vcov_fix}{Logical scalar, default is \code{TRUE}. If the VCOV ends up not being
 positive definite, whether to "fix" it using an eigenvalue decomposition
 (a la Cameron, Gelbach & Miller 2011).
 Since the VCOV should be PSD asymptotically, this might be a sign of a problem
@@ -25,7 +25,7 @@ with using the asymptotic approximation (e.g. too few units in clusters).
 If a problem is detected, the function will print a message to inform you.
 Note that a message informs the user \strong{only if} the regularized PD matrix is
 substantially different than the original non PD one (i.e. at least one difference
-between the two greated than 1e-8).}
+between the two greater than 1e-8).}
 }
 \value{
 If the first argument is a \code{fixest} object, then a VCOV is returned (i.e. a symmetric matrix).

--- a/man/vcov_conley.Rd
+++ b/man/vcov_conley.Rd
@@ -47,7 +47,7 @@ By default the VCOV is multiplied by (N - 1) / (N - K) with N the number of
 observations and K the number of parameters.
 To remove this adjustment, use \code{ssc=ssc(K.adj = FALSE)}.}
 
-\item{vcov_fix}{Logical scalar, default is \code{FALSE}. If the VCOV ends up not being
+\item{vcov_fix}{Logical scalar, default is \code{TRUE}. If the VCOV ends up not being
 positive definite, whether to "fix" it using an eigenvalue decomposition
 (a la Cameron, Gelbach & Miller 2011).
 Since the VCOV should be PSD asymptotically, this might be a sign of a problem
@@ -55,7 +55,7 @@ with using the asymptotic approximation (e.g. too few units in clusters).
 If a problem is detected, the function will print a message to inform you.
 Note that a message informs the user \strong{only if} the regularized PD matrix is
 substantially different than the original non PD one (i.e. at least one difference
-between the two greated than 1e-8).}
+between the two greater than 1e-8).}
 }
 \value{
 If the first argument is a \code{fixest} object, then a VCOV is returned (i.e. a symmetric matrix).

--- a/man/vcov_hac.Rd
+++ b/man/vcov_hac.Rd
@@ -42,7 +42,7 @@ To remove the (N - 1) / (N - K) adjustment, use \code{ssc=ssc(K.adj = FALSE)}.
 To remove the T / (T - 1) adjustment, use \code{ssc=ssc(G.adj = FALSE)}.
 To remove both, use \code{ssc=ssc(K.adj = FALSE, G.adj = FALSE)}.}
 
-\item{vcov_fix}{Logical scalar, default is \code{FALSE}. If the VCOV ends up not being
+\item{vcov_fix}{Logical scalar, default is \code{TRUE}. If the VCOV ends up not being
 positive definite, whether to "fix" it using an eigenvalue decomposition
 (a la Cameron, Gelbach & Miller 2011).
 Since the VCOV should be PSD asymptotically, this might be a sign of a problem
@@ -50,7 +50,7 @@ with using the asymptotic approximation (e.g. too few units in clusters).
 If a problem is detected, the function will print a message to inform you.
 Note that a message informs the user \strong{only if} the regularized PD matrix is
 substantially different than the original non PD one (i.e. at least one difference
-between the two greated than 1e-8).}
+between the two greater than 1e-8).}
 
 \item{unit}{A character scalar or a one sided formula giving the name of the
 variable representing the units of the panel.}

--- a/man/vcov_hetero.Rd
+++ b/man/vcov_hetero.Rd
@@ -28,7 +28,7 @@ sample correction. Note that this argument is only used in \code{"HC1"} which ac
 ssc arguments starting with \code{"K"}. In that case when \code{ssc(K.adj = FALSE)},
 it leads to "HC0". The argument \code{ssc} is ignored for \code{HC2} and \code{HC2} VCOVs.}
 
-\item{vcov_fix}{Logical scalar, default is \code{FALSE}. If the VCOV ends up not being
+\item{vcov_fix}{Logical scalar, default is \code{TRUE}. If the VCOV ends up not being
 positive definite, whether to "fix" it using an eigenvalue decomposition
 (a la Cameron, Gelbach & Miller 2011).
 Since the VCOV should be PSD asymptotically, this might be a sign of a problem
@@ -36,7 +36,7 @@ with using the asymptotic approximation (e.g. too few units in clusters).
 If a problem is detected, the function will print a message to inform you.
 Note that a message informs the user \strong{only if} the regularized PD matrix is
 substantially different than the original non PD one (i.e. at least one difference
-between the two greated than 1e-8).}
+between the two greater than 1e-8).}
 }
 \value{
 If the first argument is a \code{fixest} object, then a VCOV is returned (i.e. a symmetric matrix).


### PR DESCRIPTION
## Changes

1. **vcov_fix @param default**: Documentation said `FALSE` but actual function default is `TRUE` — fixed in `R/methods.R` and all generated Rd files.

2. **Typo fixes in roxygen source**:
   - `R/methods.R:417`: "greated" → "greater"
   - `R/VCOV.R:187`: "Furhter" → "Further"
   - `R/panel.R:580`: "occurence" → "occurrence"

3. **Regenerated Rd files**: `vcov.fixest.Rd`, `lag.formula.Rd`, and all `vcov_*` Rd files that inherit the `vcov_fix` parameter.

## Validation
- `R CMD build .` — Success
- `R CMD check --no-manual` — Pass (1 NOTE about Makevars, unrelated to changes)
- All tests pass
