### PR TITLE
fix: typos in error messages and code comments

### DIFF
--- a/R/VCOV.R
+++ b/R/VCOV.R
@@ -519,7 +519,7 @@ vcov.fixest = function(object, vcov = NULL, se = NULL, cluster, ssc = NULL, attr
             stop("To compute a clustered VCOV from a '.fit' estimation, you need to provide the variables over which to cluster with the function vcov_cluster(). E.g. vcov = vcov_cluster(cluster = df) with df a data.frame containing the clusters. Or make a regular estimation, i.e. not from '.fit'.")
           }
           if(!n_FE %in% n_patterns){
-            stop("To compute a clustered VCOV from a '.fit' estimation, you need to provide the variables over which to cluster with the function vcov = vcov_cluster(cluster = df), with df a data.frmae containing the clusters. Or make a regular estimation, i.e. not from '.fit'.")
+            stop("To compute a clustered VCOV from a '.fit' estimation, you need to provide the variables over which to cluster with the function vcov = vcov_cluster(cluster = df), with df a data.frame containing the clusters. Or make a regular estimation, i.e. not from '.fit'.")
           }
         } else {
           stop("The estimations from '.fit' methods don't support ", vcov_select$vcov_label, " VCOVs. To use them, perform a regular estimation instead.")
@@ -1356,7 +1356,7 @@ vcov_cluster = function(x, cluster = NULL, ssc = NULL, vcov_fix = TRUE){
 
       # Some further checking
       if(!is.atomic(vcov_vars[[1]])){
-        stop("If the argument 'cluster' it to be a list, it must be made of atomic vectors representing the vectors on which to cluster. Currently its first element is of class '", class(vcov_vars[[1]])[1], "'.")
+        stop("If the argument 'cluster' is to be a list, it must be made of atomic vectors representing the vectors on which to cluster. Currently its first element is of class '", class(vcov_vars[[1]])[1], "'.")
       }
 
     }

--- a/R/methods.R
+++ b/R/methods.R
@@ -4446,7 +4446,7 @@ hatvalues.fixest = function(model, exact = TRUE, boot.size = 1000, ...){
   
   mats$fixef = sparse_model_matrix(model, type = "fixef", collin.rm = TRUE, sortCols = FALSE)
 
-  # Check for slope.vars and move to seperate matrix
+  # Check for slope.vars and move to separate matrix
   if (!is.null(model$slope_flag)) {
     slope_var_cols = which(
       grepl("\\[\\[", colnames(mats$fixef))


### PR DESCRIPTION
## Changes

1. **VCOV.R:522**: Fix typo 'data.frmae' → 'data.frame' in clustered VCOV error message for `.fit` methods.

2. **VCOV.R:1359**: Fix grammar 'it to be' → 'is to be' in `vcov_cluster()` validation error.

3. **methods.R:4449**: Fix typo 'seperate' → 'separate' in code comment.

### Notes
- VCOV.R fixes (lines 522, 1359) overlap with PR #656. This PR includes them for completeness.
- The methods.R fix (line 4449) is unique to this PR.

### Validation
- `R CMD build .` — Success
- `R CMD check --no-manual` — Pass (1 NOTE about Makevars, unrelated to changes)
- Tests: Pre-existing test failure on `feols` IV regression (line 287), unrelated to these changes
