### PR TITLE
fix: typo 'disussed' -> 'discussed', missing comma in hatvalues.fixest docs

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -4363,7 +4363,7 @@ deviance.fixest = function(object, ...){
 #' @details
 #' Hat values are not available for [`fenegbin`][fixest::femlm], [`femlm`] and [`feNmlm`] estimations.
 #' 
-#' Hat values for generalized linear model are disussed in Belsley, Kuh and Welsch (1980), Cook and Weisberg (1982), etc.
+#' Hat values for generalized linear model are discussed in Belsley, Kuh and Welsch (1980), Cook and Weisberg (1982), etc.
 #' 
 #' When `exact == FALSE`, the Johnson-Lindenstrauss approximation (JLA) algorithm is used which approximates the diagonals of the projection matrix. For more precision (but longer time), increase the value of `boot.size`. See Kline, Saggio, and Sølvsten (2020) for details.
 #' 
@@ -4371,7 +4371,7 @@ deviance.fixest = function(object, ...){
 #' @references
 #' Belsley, D. A., Kuh, E. and Welsch, R. E. (1980). *Regression Diagnostics*. New York: Wiley.
 #' Cook, R. D. and Weisberg, S. (1982). *Residuals and Influence in Regression*. London: Chapman and Hall.
-#' Kline, P., Saggio R., and Sølvsten, M. (2020). *Leave‐Out Estimation of Variance Components*. Econometrica.
+#' Kline, P., Saggio, R., and Sølvsten, M. (2020). *Leave‐Out Estimation of Variance Components*. Econometrica.
 #' 
 #' @examples
 #'

--- a/man/hatvalues.fixest.Rd
+++ b/man/hatvalues.fixest.Rd
@@ -24,7 +24,7 @@ Computes the hat values for \code{\link{feols}} or \code{\link{feglm}} estimatio
 \details{
 Hat values are not available for \code{\link[=femlm]{fenegbin}}, \code{\link{femlm}} and \code{\link{feNmlm}} estimations.
 
-Hat values for generalized linear model are disussed in Belsley, Kuh and Welsch (1980), Cook and Weisberg (1982), etc.
+Hat values for generalized linear model are discussed in Belsley, Kuh and Welsch (1980), Cook and Weisberg (1982), etc.
 
 When \code{exact == FALSE}, the Johnson-Lindenstrauss approximation (JLA) algorithm is used which approximates the diagonals of the projection matrix. For more precision (but longer time), increase the value of \code{boot.size}. See Kline, Saggio, and Sølvsten (2020) for details.
 }
@@ -37,5 +37,5 @@ head(hatvalues(est))
 \references{
 Belsley, D. A., Kuh, E. and Welsch, R. E. (1980). \emph{Regression Diagnostics}. New York: Wiley.
 Cook, R. D. and Weisberg, S. (1982). \emph{Residuals and Influence in Regression}. London: Chapman and Hall.
-Kline, P., Saggio R., and Sølvsten, M. (2020). \emph{Leave‐Out Estimation of Variance Components}. Econometrica.
+Kline, P., Saggio, R., and Sølvsten, M. (2020). \emph{Leave‐Out Estimation of Variance Components}. Econometrica.
 }


### PR DESCRIPTION
## Summary

Fixes two minor issues in the `hatvalues.fixest` documentation:

1. **Typo**: `disussed` → `discussed` in the `@details` section
2. **Missing comma**: `Saggio R.` → `Saggio, R.` in the Kline et al. (2020) reference

### Files changed

- `R/methods.R` — Fixed both roxygen comments
- `man/hatvalues.fixest.Rd` — Regenerated via `roxygen2::roxygenise()`

### Validation

- `R CMD build --no-build-vignettes .` — Success
- `R CMD check --no-manual --no-vignettes` — Pass (2 pre-existing WARNINGs about vignettes, 1 NOTE about Makevars, all unrelated to changes)
- All tests pass

### Duplicate check

No open PRs address the `hatvalues.fixest` documentation.
