### PR TITLE
fix: typos in coefplot docs (decrese, patch, tha, line with)

### DIFF
--- a/R/coefplot.R
+++ b/R/coefplot.R
@@ -54,13 +54,13 @@
 #' graph. Note that if it is the case, then the argument `x` MUST be numeric.
 #' @param xlim Numeric vector of length 2 which gives the limits of the plotting region for
 #' the x-axis. The default is `NULL`, which means that it is automatically defined.
-#' Use the argument `xlim.add` to simply increase or decrese the default limits.
+#' Use the argument `xlim.add` to simply increase or decrease the default limits.
 #' @param ylim Numeric vector of length 2 which gives the limits of the plotting region for
 #' the y-axis. The default is `NULL`, which means that it is automatically defined.
-#' Use the argument `ylim.add` to simply increase or decrese the default limits.
-#' @param pch The patch of the coefficient estimates. Default is 1 (circle). 
-#' This is an alias to tha argument `pt.pch`.
-#' @param pt.pch The patch of the coefficient estimates. Default is 1 (circle).
+#' Use the argument `ylim.add` to simply increase or decrease the default limits.
+#' @param pch The pch of the coefficient estimates. Default is 1 (circle). 
+#' This is an alias to the argument `pt.pch`.
+#' @param pt.pch The pch of the coefficient estimates. Default is 1 (circle).
 #' @param cex Numeric, default is 1. Expansion factor for the points
 #' @param pt.cex The size of the coefficient estimates. Default is the other argument `cex`.
 #' @param col The color of the points and the confidence intervals. Default is 1 
@@ -68,7 +68,7 @@
 #' with `pt.col` and `ci.col`.
 #' @param pt.col The color of the coefficient estimates. Default is equal to the argument `col`.
 #' @param ci.col The color of the confidence intervals. Default is equal to the argument `col`.
-#' @param lwd General line with. Default is 1.
+#' @param lwd General line width. Default is 1.
 #' @param lty The line type of the confidence intervals. Default is 1. 
 #' This is an alias to the argument `ci.lty`.
 #' @param pt.lwd The line width of the coefficient estimates. Default is equal to 

--- a/man/coefplot.Rd
+++ b/man/coefplot.Rd
@@ -257,8 +257,8 @@ graph. Note that if it is the case, then the argument \code{x} MUST be numeric.}
 \item{plot_prms}{A named list. It may contain additionnal parameters to be passed
 to the plot.}
 
-\item{pch}{The patch of the coefficient estimates. Default is 1 (circle).
-This is an alias to tha argument \code{pt.pch}.}
+\item{pch}{The pch of the coefficient estimates. Default is 1 (circle).
+This is an alias to the argument \code{pt.pch}.}
 
 \item{col}{The color of the points and the confidence intervals. Default is 1
 ("black"). Note that you can set the colors separately for each of them
@@ -269,17 +269,17 @@ with \code{pt.col} and \code{ci.col}.}
 \item{lty}{The line type of the confidence intervals. Default is 1.
 This is an alias to the argument \code{ci.lty}.}
 
-\item{lwd}{General line with. Default is 1.}
+\item{lwd}{General line width. Default is 1.}
 
 \item{ylim}{Numeric vector of length 2 which gives the limits of the plotting region for
 the y-axis. The default is \code{NULL}, which means that it is automatically defined.
-Use the argument \code{ylim.add} to simply increase or decrese the default limits.}
+Use the argument \code{ylim.add} to simply increase or decrease the default limits.}
 
 \item{xlim}{Numeric vector of length 2 which gives the limits of the plotting region for
 the x-axis. The default is \code{NULL}, which means that it is automatically defined.
-Use the argument \code{xlim.add} to simply increase or decrese the default limits.}
+Use the argument \code{xlim.add} to simply increase or decrease the default limits.}
 
-\item{pt.pch}{The patch of the coefficient estimates. Default is 1 (circle).}
+\item{pt.pch}{The pch of the coefficient estimates. Default is 1 (circle).}
 
 \item{pt.bg}{The background color of the point estimate (when the \code{pt.pch} is
 in 21 to 25). Defaults to NULL.}

--- a/man/plot.fixest.Rd
+++ b/man/plot.fixest.Rd
@@ -131,14 +131,14 @@ to the plot.}
 
 \item{ylim}{Numeric vector of length 2 which gives the limits of the plotting region for
 the y-axis. The default is \code{NULL}, which means that it is automatically defined.
-Use the argument \code{ylim.add} to simply increase or decrese the default limits.}
+Use the argument \code{ylim.add} to simply increase or decrease the default limits.}
 
 \item{xlim}{Numeric vector of length 2 which gives the limits of the plotting region for
 the x-axis. The default is \code{NULL}, which means that it is automatically defined.
-Use the argument \code{xlim.add} to simply increase or decrese the default limits.}
+Use the argument \code{xlim.add} to simply increase or decrease the default limits.}
 
-\item{pch}{The patch of the coefficient estimates. Default is 1 (circle).
-This is an alias to tha argument \code{pt.pch}.}
+\item{pch}{The pch of the coefficient estimates. Default is 1 (circle).
+This is an alias to the argument \code{pt.pch}.}
 
 \item{col}{The color of the points and the confidence intervals. Default is 1
 ("black"). Note that you can set the colors separately for each of them
@@ -149,9 +149,9 @@ with \code{pt.col} and \code{ci.col}.}
 \item{lty}{The line type of the confidence intervals. Default is 1.
 This is an alias to the argument \code{ci.lty}.}
 
-\item{lwd}{General line with. Default is 1.}
+\item{lwd}{General line width. Default is 1.}
 
-\item{pt.pch}{The patch of the coefficient estimates. Default is 1 (circle).}
+\item{pt.pch}{The pch of the coefficient estimates. Default is 1 (circle).}
 
 \item{pt.bg}{The background color of the point estimate (when the \code{pt.pch} is
 in 21 to 25). Defaults to NULL.}

--- a/man/setFixest_coefplot.Rd
+++ b/man/setFixest_coefplot.Rd
@@ -87,7 +87,7 @@ does not contain \dQuote{Constant} is kept). See details.}
 
 \item{ci_level}{Scalar between 0 and 1: the level of the CI. By default it is equal to 0.95.}
 
-\item{pt.pch}{The patch of the coefficient estimates. Default is 1 (circle).}
+\item{pt.pch}{The pch of the coefficient estimates. Default is 1 (circle).}
 
 \item{pt.bg}{The background color of the point estimate (when the \code{pt.pch} is
 in 21 to 25). Defaults to NULL.}
@@ -104,7 +104,7 @@ with \code{pt.col} and \code{ci.col}.}
 
 \item{ci.col}{The color of the confidence intervals. Default is equal to the argument \code{col}.}
 
-\item{lwd}{General line with. Default is 1.}
+\item{lwd}{General line width. Default is 1.}
 
 \item{pt.lwd}{The line width of the coefficient estimates. Default is equal to
 the other argument \code{lwd}.}


### PR DESCRIPTION
## Changes

Fix 5 typos in `R/coefplot.R` roxygen comments (propagated to `coefplot.Rd`, `plot.fixest.Rd`, `setFixest_coefplot.Rd`):

1. **Line 57**: `decrese` → `decrease` (xlim.add param)
2. **Line 60**: `decrese` → `decrease` (ylim.add param)
3. **Lines 61, 63**: `patch` → `pch` (pch/pt.pch param descriptions)
4. **Line 62**: `tha` → `the` (alias cross-reference)
5. **Line 71**: `line with` → `line width` (lwd param)

### Files changed
- `R/coefplot.R` — Fixed 5 roxygen typos
- `man/coefplot.Rd`, `man/plot.fixest.Rd`, `man/setFixest_coefplot.Rd` — Regenerated via `roxygen2::roxygenise()`

### Validation
- `R CMD build --no-build-vignettes .` — Success
- `R CMD check --no-manual --no-vignettes` — Pass (2 pre-existing WARNINGs about vignettes, 1 NOTE about Makevars, all unrelated)
- Tests pass
- Duplicate check: no open PRs addressing coefplot docs