### PR TITLE
fix: typos in roxygen docs (VCOV, estimation, fixest_multi, panel)

### DIFF
--- a/R/VCOV.R
+++ b/R/VCOV.R
@@ -2946,7 +2946,7 @@ print.ssc_type = function(x, ...){
 #' "iid", "hetero", "cluster", "twoway", "newey", "driscoll", "conley".
 #' 
 #' @return 
-#' This functions invisibly returns the list of old settings, a list of class `setFixest_ssc`.
+#' This function invisibly returns the list of old settings, a list of class `setFixest_ssc`.
 #' 
 #' @seealso 
 #' [`vcov.fixest`], [`ssc`], [`getFixest_ssc`]
@@ -3094,7 +3094,7 @@ getFixest_ssc = function(vcov_name = NULL){
 
 #' Sets the default type of standard errors to be used
 #'
-#' This functions defines or extracts the default type of standard-errors to computed in 
+#' This function defines or extracts the default type of standard-errors to be computed in 
 #' `fixest` [`summary`][fixest::summary.fixest], and [`vcov`][fixest::vcov.fixest].
 #'
 #' @param no_FE Character scalar equal to either: `"iid"` (default), or `"hetero"`. The type 
@@ -3105,11 +3105,11 @@ getFixest_ssc = function(vcov_name = NULL){
 #' `"twoway"`. The type of standard-errors to use by default for estimations with *two or more* 
 #' fixed-effects.
 #' @param panel Character scalar equal to either: `"iid"` (default), `"hetero"`, `"cluster"`, or 
-#' `"driscoll_kraaay"`. The type of standard-errors to use by default for estimations with the 
+#' `"driscoll_kraay"`. The type of standard-errors to use by default for estimations with the 
 #' argument `panel.id` set up. Note that panel has precedence over the presence of fixed-effects.
 #' @param all Character scalar equal to either: `"iid"`, or `"hetero"` (or `"cluster"` if 
 #' the argument `no_FE` is provided). 
-#' By default is is `NULL`. If provided, it sets all the SEs to that value. 
+#' By default it is `NULL`. If provided, it sets all the SEs to that value. 
 #' @param reset Logical, default is `FALSE`. Whether to reset to the default values.
 #'
 #' @return

--- a/R/estimation.R
+++ b/R/estimation.R
@@ -281,7 +281,7 @@
 #' \item{obs_selection}{(When relevant.) List containing vectors of integers. It represents the sequential selection of observation vis a vis the original data set.}
 #' \item{collin.var}{(When relevant.) Vector containing the variables removed because of collinearity.}
 #' \item{collin.coef}{(When relevant.) Vector of coefficients, where the values of the variables removed because of collinearity are NA.}
-#' \item{collin.min_norm}{The minimal diagonal value of the Cholesky decomposition. Small values indicate possible presence collinearity.}
+#' \item{collin.min_norm}{The minimal diagonal value of the Cholesky decomposition. Small values indicate possible presence of collinearity.}
 #' \item{y_demeaned}{Only when `demeaned = TRUE`: the centered dependent variable.}
 #' \item{X_demeaned}{Only when `demeaned = TRUE`: the centered explanatory variable.}
 #'

--- a/R/fixest_multi.R
+++ b/R/fixest_multi.R
@@ -808,7 +808,7 @@ print.fixest_multi = function(x, type = "etable", ...){
 #' Its default value can be modified with the function [`setFixest_multi`].
 #'
 #' @details
-#' The order with we we use the keys matter. Every time a key `sample`, `lhs`, `rhs`, 
+#' The order in which we use the keys matters. Every time a key `sample`, `lhs`, `rhs`, 
 #' `fixef` or `iv` is used, a reordering is performed to consider the leftmost-side key 
 #' to be the new root.
 #'

--- a/R/panel.R
+++ b/R/panel.R
@@ -900,7 +900,7 @@ unpanel = function(x){
 #'
 #' @return
 #' It returns a `fixest_panel` data base, with the attributes allowing to create 
-#' lags/leads properly bookkeeped.
+#' lags/leads properly bookkept.
 #'
 #' @author
 #' Laurent Berge


### PR DESCRIPTION
## Summary

Fixes 7 roxygen documentation typos across 4 files:

### R/VCOV.R (4 fixes)
- Line 2949: "This functions invisibly" → "This function invisibly"
- Line 3097: "This functions defines" → "This function defines", "to computed" → "to be computed"
- Line 3108: "driscoll_kraaay" → "driscoll_kraay" (triple 'a' typo in `@param panel`)
- Line 3112: "is is" → "it is"

### R/estimation.R (1 fix)
- Line 284: "possible presence collinearity" → "possible presence of collinearity"

### R/fixest_multi.R (1 fix)
- Line 811: "with we we use the keys matter" → "in which we use the keys matters"

### R/panel.R (1 fix)
- Line 903: "bookkeeped" → "bookkept"

## Validation

- `R CMD build --no-build-vignettes` — success
- `R CMD check --no-manual --no-vignettes --no-tests` — Status: OK (pre-existing vignette warnings only)

## Notes

- All changes are in roxygen comments only; no functional code modified
- No overlap with existing PRs (#654–#661)