### PR TITLE
fix: typos in roxygen docs (did.R, etable.R)

### DIFF
--- a/R/did.R
+++ b/R/did.R
@@ -45,7 +45,7 @@
 #' you can use the special value `"bin::digit"` to group every `digit` element. 
 #' For example if `x` represent years, using `bin="bin::2"` create bins of two years. 
 #' Using `"!bin::digit"` groups every digit consecutive values starting from the first value. 
-#' Using `"!!bin::digit"` is the same bu starting from the last value. In both cases, 
+#' Using `"!!bin::digit"` is the same but starting from the last value. In both cases, 
 #' `x` is not required to be numeric.
 #' @param bin.rel A list or a vector defining which values to bin. Only applies to the 
 #' relative periods and *not* the cohorts. Please refer to the help of the argument 

--- a/R/etable.R
+++ b/R/etable.R
@@ -175,8 +175,8 @@
 #' A line can be represented by: i) a character vector, ii) a list of the form 
 #' `list("value1" = nb1, "value2" = nb2, etc)`. In the list form, numeric numbers 
 #' represent spans and integers represent absolute positions. 
-#' Example: `headers=lits(Gender = list("M"=2, "F"=3))` will create a 
-#' row with 2 times "M" and three time "F" (this is identical to 
+#' Example: `headers=list(Gender = list("M"=2, "F"=3))` will create a 
+#' row with 2 times "M" and three times "F" (this is identical to 
 #' `headers=list(Gender = c("M", "M", "F", "F", "F"))`). 
 #' You can stack header lines within a list, in that case the 
 #' list names will be displayed in the leftmost cell. 


### PR DESCRIPTION
## Problem

3 roxygen documentation typos across 2 files not covered by existing PRs:

1. `R/did.R:48` — "same bu" → "same but" (missing letter in `bin` param docs)
2. `R/etable.R:178` — `headers=lits(...)` → `headers=list(...)` (typo in code example)
3. `R/etable.R:179` — "three time" → "three times" (grammar in headers docs)

## Files changed
- `R/did.R` — 1 typo in `sunab()` `bin` parameter documentation
- `R/etable.R` — 2 typos in `etable()` `headers` parameter documentation

## Validation
- `R CMD build --no-build-vignettes` — success
- `R CMD check --no-manual --no-vignettes --no-tests` — Status: OK (pre-existing vignette warnings only)
- Duplicate check: verified no overlap with PRs #654–#662 (none touch did.R or etable.R)