### PR TITLE
fix: typos in methods.R (nobs/AIC docs), fitstats.R, miscfuns.R, fixest_env.R, sparse_model_matrix.R, collinearity.Rmd

### DIFF
--- a/R/fitstats.R
+++ b/R/fitstats.R
@@ -366,7 +366,7 @@ fitstat_register = function(type, fun, alias = NULL, subtypes = NULL){
           stop("In the argument 'alias': only the main type can be implicitly set and should come first (they are several implicitly defined atm). Please explicitly use names for each type/subtype you want.")
 
         } else if(is_0 != 1){
-          stop("In the argument 'alias': only the main type can be implicitly set and should come first (it is currenly not first). Please explicitly use names for each type/subtype you want.")
+          stop("In the argument 'alias': only the main type can be implicitly set and should come first (it is currently not first). Please explicitly use names for each type/subtype you want.")
 
         }
 

--- a/R/fixest_env.R
+++ b/R/fixest_env.R
@@ -704,7 +704,7 @@ fixest_env = function(fml, data, family = c("poisson", "negbin", "logit", "gauss
           msg_builder = function(var_pblm, type, qui){
             msg = ""
             if(any(type[qui] == "var")){
-              msg = " Note that fixest does not accept variables from the global enviroment, they must be in the data set"
+              msg = " Note that fixest does not accept variables from the global environment, they must be in the data set"
               extra = "."
               if(!all(type[qui] == "var")){
                 extra = paste0(" (it concerns ", enumerate_items(var_pblm[qui][type[qui] == "var"]), ").")

--- a/R/methods.R
+++ b/R/methods.R
@@ -1951,9 +1951,9 @@ pvalue.fixest = function(object, vcov = NULL, ssc = NULL, cluster = NULL,
 
 
 
-#' Extracts the number of observations form a `fixest` object
+#' Extracts the number of observations from a `fixest` object
 #'
-#' This function simply extracts the number of observations form a `fixest` object, 
+#' This function simply extracts the number of observations from a `fixest` object, 
 #' obtained using the functions [`femlm`], [`feols`] or [`feglm`].
 #'
 #' @inheritParams summary.fixest
@@ -1970,7 +1970,7 @@ pvalue.fixest = function(object, vcov = NULL, ssc = NULL, cluster = NULL,
 #' Laurent Berge
 #'
 #' @return
-#' It returns an interger.
+#' It returns an integer.
 #'
 #' @examples
 #'
@@ -1986,9 +1986,9 @@ nobs.fixest = function(object, ...){
   object$nobs
 }
 
-#' Akaike's an information criterion
+#' Akaike information criterion
 #'
-#' This function computes the AIC (Akaike's, an information criterion) from a `fixest` estimation.
+#' This function computes the AIC (Akaike's information criterion) from a `fixest` estimation.
 #'
 #' @inheritParams nobs.fixest
 #'

--- a/R/miscfuns.R
+++ b/R/miscfuns.R
@@ -4959,7 +4959,7 @@ fetch_data = function(x, prefix = "", suffix = "", no_error = FALSE){
 
   data_name = charShorten(deparse(x$call$data)[1], 15)
   
-  msg = sma(begin, " fetch the data in the enviroment where the estimation was made, but the data does not seem to be there any more (btw it was {bq ? data_name}). ", suffix)
+  msg = sma(begin, " fetch the data in the environment where the estimation was made, but the data does not seem to be there any more (btw it was {bq ? data_name}). ", suffix)
   
   if(no_error){
     class(msg) = "error"

--- a/R/sparse_model_matrix.R
+++ b/R/sparse_model_matrix.R
@@ -16,7 +16,7 @@
 #' @param na.rm Default is `FALSE`. Should observations with NAs be removed from the matrix?
 #' @param collin.rm Logical scalar. Whether to remove variables that were 
 #' found to be collinear during the estimation. Beware: it does not perform a 
-#' collinearity check and bases on the `coef(object)`. 
+#' collinearity check and based on the `coef(object)`. 
 #' Default is TRUE if object is a `fixest` object, or `FALSE` if object is a formula.
 #' @param combine Logical scalar, default is `TRUE`. Whether to combine each 
 #' resulting sparse matrix.

--- a/vignettes/collinearity.Rmd
+++ b/vignettes/collinearity.Rmd
@@ -193,20 +193,20 @@ In this section we first detail how most software remove collinear variables and
 In general the process of collinearity fixing by variable removal is as follows:
 
 * for each explanatory variable, from left to right, *following the order of the variables given by the user* (this is important):
-  * check wether the current variable is positive to a collinearity test with the variables previously done:
+  * check whether the current variable is positive to a collinearity test with the variables previously done:
     * if collinear: remove it
     * else: continue
 
 It is important to stress that we are not talking about *mathematical collinearity* but only about *numerical collinearity* which are two different beasts. 
-Indeed, the results of collinearity detection and fixing depend on the rountines' algorithms. This means that two different routines can lead to different results due to their diverging algorithms -- although this should be the excteption rather than the rule.
+Indeed, the results of collinearity detection and fixing depend on the routines' algorithms. This means that two different routines can lead to different results due to their diverging algorithms -- although this should be the exception rather than the rule.
 
 Let us give two examples. In `R`, the function `lm` uses a QR decomposition of the matrix $X$ to solve the OLS problem. Linear dependencies (collinearity) are resolved during the QR decomposition. 
-Differently from `lm`, the function `feols` from `fixest` resolves collinearity during a Cholesky decompostion of the matrix $X^\prime X$. While there are major advantages in terms of speed to use this method, it is known to be inferior to the QR method for collinearity detection because using $X^\prime X$ instead of $X$ reduces numeric precision. 
+Differently from `lm`, the function `feols` from `fixest` resolves collinearity during a Cholesky decomposition of the matrix $X^\prime X$. While there are major advantages in terms of speed to use this method, it is known to be inferior to the QR method for collinearity detection because using $X^\prime X$ instead of $X$ reduces numeric precision.
 In the vast majority of cases however, the two methods are equivalent and provide similar results.
 
 ## Collinearity is a numerical problem
 
-To nail the fact that collinearity fixing in econometrics sowftare is a numerical problem, we give the following example. Consider the OLS estimation of this simple model:
+To nail the fact that collinearity fixing in econometrics software is a numerical problem, we give the following example. Consider the OLS estimation of this simple model:
 
 $$ y = \alpha + \beta x + \epsilon $$
 
@@ -297,7 +297,7 @@ lm(y ~ I(x + 1e7), df) |> coef()
 
 Contrary to `feols`, for a translation of 1,000,000 `lm` does not remove the variable and gives the right result. However, the behavior becomes similar to that of `feols` when we apply a translation of $10^7$. A notable difference between the two routines is that there is no explicit message from `lm` (but this is displayed in `lm`'s `summary`).
 
-**Bottom line.** Collinearity detection and fixing is a numerical problem and as such is subject to the ususal pitfall of these, in particular precision problems. Always be wary when variables are removed: if there is no theoretical reason for removal then there might be a data problem. In general, ensuring that the variables have a reasonable numerical range is a good idea. Do not hesitate to re-scale the variables with a large range.
+**Bottom line.** Collinearity detection and fixing is a numerical problem and as such is subject to the usual pitfall of these, in particular precision problems. Always be wary when variables are removed: if there is no theoretical reason for removal then there might be a data problem. In general, ensuring that the variables have a reasonable numerical range is a good idea. Do not hesitate to re-scale the variables with a large range.
 
 ## When automatic removal is good {#subsec_removal_good}
 


### PR DESCRIPTION
## Summary

Fixes typos in R source documentation and the collinearity vignette.

## Changes

**R/methods.R** (nobs.fixest and AIC.fixest docs):
- "form a" → "from a" (title and description of `nobs.fixest`)
- "interger" → "integer" (return value of `nobs.fixest`)
- "Akaike's an information criterion" → "Akaike information criterion" (title)
- "Akaike's, an information criterion" → "Akaike's information criterion" (description)

**R/sparse_model_matrix.R**:
- "bases on" → "based on" (collin.rm param docs)

**R/fitstats.R**:
- "currenly" → "currently" (error message in alias handling)

**R/miscfuns.R**:
- "enviroment" → "environment" (error message in data fetch)

**R/fixest_env.R**:
- "enviroment" → "environment" (error message for global env variables)

**vignettes/collinearity.Rmd**:
- "wether" → "whether"
- "rountines'" → "routines'"
- "excteption" → "exception"
- "decompostion" → "decomposition"
- "sowftare" → "software"
- "ususal" → "usual"

## Validation

- Changes are limited to documentation strings and error messages
- No behavioral changes to package functionality
- All fixes are straightforward typo corrections