### PR TITLE
Change subset timing in fixest panel

### DIFF
--- a/R/fixest_env.R
+++ b/R/fixest_env.R
@@ -1125,6 +1125,9 @@ fixest_env = function(fml, data, family = c("poisson", "negbin", "logit", "gauss
 
         additional_vars = collect_vars(NL.fml, offset, weights, split, fsplit)
         complete_vars = c(complete_vars, additional_vars)
+        if(isPanel){
+          complete_vars = c(complete_vars, all.vars(panel__meta__info$panel.id))
+        }
 
         complete_vars = intersect(unique(complete_vars), names(data))
 
@@ -1133,6 +1136,15 @@ fixest_env = function(fml, data, family = c("poisson", "negbin", "logit", "gauss
 
       # We add subset to the obs selected
       obs_selection = list(subset = subset)
+
+      if(isPanel){
+        if(isFit){
+          panel__meta__info = panel_subset(panel__meta__info, subset)
+        } else {
+          panel__meta__info = panel_subset(panel__meta__info, subset, data,
+                                           from_fixest = TRUE)
+        }
+      }
 
     } else if(!is.null(mc_origin$subset)){
       dp = deparse_long(mc_origin$subset)
@@ -4882,4 +4894,3 @@ split_select = function(items, keep, drop){
 
   which(items %in% res)
 }
-

--- a/R/panel.R
+++ b/R/panel.R
@@ -141,6 +141,15 @@ panel_setup = function(data, panel.id, time.step = NULL, duplicate.method = "non
     }
   }
 
+  if(length(time) == 0){
+    res = list(order_it = integer(0), order_inv = integer(0),
+               id_sorted = integer(0), time_sorted = integer(0),
+               na_flag = na_flag, panel.id = panel.id,
+               time.step = time.step, duplicate.method = duplicate.method)
+    if(na_flag) res$is_na = is_na
+    return(res)
+  }
+
   # Creation of the indexes
   id = to_index_internal(id)
   time_full = to_index_internal(time, add_items = TRUE, sorted = TRUE)
@@ -228,7 +237,8 @@ panel_setup = function(data, panel.id, time.step = NULL, duplicate.method = "non
   }
 
   res = list(order_it = order_it, order_inv = order_inv, id_sorted = id_sorted, 
-             time_sorted = time_sorted, na_flag = na_flag, panel.id = panel.id)
+             time_sorted = time_sorted, na_flag = na_flag, panel.id = panel.id,
+             time.step = time.step, duplicate.method = duplicate.method)
   
   if(na_flag) res$is_na = is_na
   res
@@ -828,6 +838,84 @@ panel = function(data, panel.id, time.step = NULL, duplicate.method = "none"){
 }
 
 
+panel_subset = function(info, select, data = NULL, from_fixest = FALSE){
+  panel_vars = all.vars(info$panel.id)
+  if(!is.null(data) && inherits(data, "data.frame") && nrow(data) > 0 &&
+     all(panel_vars %in% names(data))){
+    time.step = info$time.step
+    duplicate.method = info$duplicate.method
+    if(is.null(duplicate.method)){
+      duplicate.method = "none"
+    }
+
+    new_info = panel_setup(data, panel.id = info$panel.id, time.step = time.step,
+                           duplicate.method = duplicate.method,
+                           from_fixest = from_fixest)
+    new_info$call = info$call
+    return(new_info)
+  }
+
+  id = info$id_sorted[info$order_inv]
+  time = info$time_sorted[info$order_inv]
+
+  if(info$na_flag == FALSE){
+    id = id[select]
+    time = time[select]
+  } else {
+    id_tmp = time_tmp = rep(NA, length(info$is_na))
+    id_tmp[!info$is_na] = id
+    time_tmp[!info$is_na] = time
+    id = id_tmp[select]
+    time = time_tmp[select]
+  }
+
+  is_na = is.na(id) | is.na(time)
+  na_flag = FALSE
+  if(any(is_na)){
+    na_flag = TRUE
+    id = id[!is_na]
+    time = time[!is_na]
+  }
+
+  time.step = info$time.step
+  if(length(time) > 0 && !is.null(time.step)){
+    if(time.step == "unitary"){
+      time_unik = sort(unique(time))
+
+      if(length(time_unik) == 1){
+        time = rep(0L, length(time))
+      } else {
+        all_steps = unique(diff(time_unik))
+        my_step = cpp_pgcd(all_steps)
+        time_unik_new = (time_unik - min(time_unik)) / my_step
+        time = time_unik_new[match(time, time_unik)]
+      }
+
+    } else if(time.step %in% c("consecutive", "within.consecutive")){
+      time = to_index_internal(time, sorted = TRUE)
+    }
+  }
+
+  time = as.integer(time)
+  order_it = order(id, time)
+  order_inv = order(order_it)
+  time_sorted = time[order_it]
+  if(identical(time.step, "within.consecutive")){
+    time_sorted = seq_along(time_sorted)
+  }
+
+  new_info = list(order_it = order_it, order_inv = order_inv,
+                  id_sorted = id[order_it], time_sorted = time_sorted,
+                  na_flag = na_flag, panel.id = info$panel.id, call = info$call,
+                  time.step = info$time.step,
+                  duplicate.method = info$duplicate.method)
+
+  if(na_flag) new_info$is_na = is_na
+
+  new_info
+}
+
+
 #' Dissolves a `fixest` panel
 #'
 #' Transforms a `fixest_panel` object into a regular data.frame.
@@ -1022,39 +1110,7 @@ unpanel = function(x){
       select = i
     }
 
-    # we modify the indexes
-    id = info$id_sorted[info$order_inv]
-    time = info$time_sorted[info$order_inv]
-
-    if(info$na_flag == FALSE){
-      id = id[select]
-      time = time[select]
-    } else{
-      # We don't forget to add the NAs!
-      id_tmp = time_tmp = rep(NA, info$is_na)
-      id_tmp[!info$is_na] = id
-      time_tmp[!info$is_na] = time
-      id = id_tmp[select]
-      time = time_tmp[select]
-    }
-
-    is_na = is.na(id) | is.na(time)
-    na_flag = FALSE
-    if(any(is_na)){
-      na_flag = TRUE
-      id = id[!is_na]
-      time = time[!is_na]
-    }
-
-    order_it = order(id, time)
-    order_inv = order(order_it)
-
-    new_info = list(order_it = order_it, order_inv = order_inv,
-                    id_sorted = id[order_it], time_sorted = time[order_it],
-                    na_flag = na_flag, panel.id = info$panel.id, call = info$call)
-
-    if(na_flag) new_info$is_na = is_na
-    attr(res, "panel_info") = new_info
+    attr(res, "panel_info") = panel_subset(info, select, res)
   }
 
   return(res)
@@ -1287,13 +1343,6 @@ set_panel_meta_info = function(object, newdata){
 
   panel__meta__info
 }
-
-
-
-
-
-
-
 
 
 

--- a/tests/fixest_tests.R
+++ b/tests/fixest_tests.R
@@ -649,6 +649,59 @@ for(depvar in c("y", "y_na", "y_0")){
 
 cat("done.\n\n")
 
+base_subset_panel = data.frame(
+  id = rep(1:4, each = 3),
+  id2 = rep(c("a", "b"), each = 6),
+  period = rep(1:3, 4),
+  x = c(3, 5, 7, 1, 4, 9, 2, 8, 6, 5, 3, 4),
+  y = c(5, 2, 9, 3, 6, 8, 4, 7, 1, 8, 5, 6)
+)
+base_subset_keep = base_subset_panel$period %in% c(1, 3)
+est_panel_presubset = feols(
+  y ~ l(x),
+  base_subset_panel[base_subset_keep, ],
+  panel.id = ~ id + period
+)
+
+for(panel_id in list(~ id + period, ~ id^id2 + period, ~ paste(id, id2) + period)){
+  test(
+    coef(feols(y ~ l(x), base_subset_panel,
+               subset = ~ period %in% c(1, 3), panel.id = panel_id)),
+    coef(feols(y ~ l(x), base_subset_panel[base_subset_keep, ],
+               panel.id = panel_id))
+  )
+}
+
+panel_subset_object = panel(base_subset_panel, ~ id + period)
+est_panel_object_subset = feols(
+  y ~ l(x),
+  panel_subset_object[panel_subset_object$period %in% c(1, 3), ]
+)
+test(coef(est_panel_object_subset), coef(est_panel_presubset))
+
+panel_subset_projected_gap = panel_subset_object[
+  panel_subset_object$period %in% c(1, 3),
+  c("y", "x")
+]
+test(coef(feols(y ~ l(x), panel_subset_projected_gap)), coef(est_panel_object_subset))
+
+panel_subset_projected = panel_subset_object[1:10, c("y", "x")]
+test(names(panel_subset_projected), c("y", "x"))
+test(
+  coef(feols(y ~ l(x), panel_subset_projected)),
+  coef(feols(y ~ l(x), panel_subset_object[1:10, ]))
+)
+
+panel_subset_empty = panel_subset_object[FALSE, ]
+test(nrow(panel_subset_empty), 0)
+test(inherits(panel_subset_empty, "fixest_panel"), TRUE)
+test(length(attr(panel_subset_empty, "panel_info")$id_sorted), 0)
+
+panel_subset_na = panel_subset_object[NA_integer_, ]
+test(nrow(panel_subset_na), 1)
+test(attr(panel_subset_na, "panel_info")$is_na, TRUE)
+test(length(attr(panel_subset_na, "panel_info")$id_sorted), 0)
+
 #
 # Data table
 #
@@ -3253,13 +3306,6 @@ est_mult = feols(y ~ x1 + x2, base, split = ~species)
 test(dim(fixest_data(est_mult)), dim(base))
 
 test(nrow(fixest_data(est_mult, "esti")), 45)
-
-
-
-
-
-
-
 
 
 


### PR DESCRIPTION
Handling lags in unbalanced panels is painful. [I found this out the hard way in Stata](https://www.statalist.org/forums/forum/general-stata-discussion/general/1753964-inconsistent-results-with-different-way-of-specifying-lags-in-xtdpd) and hit another issue in `fixest`. Specifically what happens is that if your `subset` formula kills off an observation at t-1, then `l()` or `d()` can't get the lag correctly. This PR attempts to fix it by changing the evaluation timing. I am not happy that I had to add a helper and pass stuff around, so if you have a better idea let me know.

It keeps the quirk that `l(x, 2)` and `l(l(x), 1)` differ because that's how it was working before. I don't like it but it's separate from this I guess.

## Repro

  ```r
  library(fixest)

  base_subset_panel <- data.frame(
    id = rep(1:4, each = 3),
    id2 = rep(c("a", "b"), each = 6),
    period = rep(1:3, 4),
    x = c(3, 5, 7, 1, 4, 9, 2, 8, 6, 5, 3, 4),
    y = c(5, 2, 9, 3, 6, 8, 4, 7, 1, 8, 5, 6)
  )

  feols(
    y ~ l(x),
    base_subset_panel,
    subset = ~ period %in% c(1, 3),
    panel.id = ~ id + period
  )

  p <- panel(base_subset_panel, ~ id + period)
  feols(y ~ l(x), p[p$period %in% c(1, 3), ])
```

## Actual behavior

  Before this change, the equivalent pre-subsetted model worked, but the subset and subsetted-panel versions would error while evaluating the panel lag.

## Expected behavior

The following should be equivalent:

  1. Passing subset to feols() with panel.id.
  2. Pre-subsetting the data before calling feols().
  3. Subsetting a fixest_panel object and then estimating with panel lag/difference operators.

## Root cause

  Panel metadata was built before the estimation subset was fully applied and was then reused after rows had been removed. That left the stored id/time indexes describing the original data rather than the data
  actually used to evaluate l(), f(), or d().

## Fix

  - Add a shared `panel_subset()` helper to rebuild or subset panel metadata after row selection.
  - Carry `time.step` and `duplicate.method` through panel_setup() metadata so subsetting can preserve the original panel behavior.
  - Update fixest_env() so panel metadata is realigned after subset.
  - Preserve panel metadata when subsetting fixest_panel objects, including empty and NA selections.

## Tests

Added regression coverage in tests/fixest_tests.R:

  1. subset with panel.id matches equivalent pre-subsetting.
  2. Compound panel ids such as id^id2 and paste(id, id2) also match.
  3. Subsetted fixest_panel objects match equivalent pre-subsetting.
  4. Projected/subsetted panels keep enough metadata for lag evaluation.
  5. Empty and NA panel subsets keep consistent panel metadata.

## Verification

  - Targeted lagging tests pass.
  - Manual before/after check: parent commit errors on the subsetted panel lag case; this branch matches the pre-subsetted coefficients.

## Disclaimer

Same as my other PR:  I had Codex help with the patch and then probed some edge cases. Tests pass locally, but let me know if you want me to check some specific thing more thoroughly.