### PR TITLE
dreamerr requirement is 1.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Authors@R:
              family = "Butts",
              role = "ctb",
              email = "buttskyle96@gmail.com"))
-Imports: stats, graphics, grDevices, tools, utils, methods, numDeriv, nlme, sandwich, Rcpp(>= 1.0.5), dreamerr(>= 1.4.0), stringmagic(>= 1.2.0)
+Imports: stats, graphics, grDevices, tools, utils, methods, numDeriv, nlme, sandwich, Rcpp(>= 1.0.5), dreamerr(>= 1.5.0), stringmagic(>= 1.2.0)
 Suggests: knitr, rmarkdown, data.table, plm, MASS, pander, ggplot2, lfe, tinytex, pdftools, emmeans, estimability, AER, Matrix
 LinkingTo: Rcpp
 Depends: R(>= 3.5.0)


### PR DESCRIPTION
CRAN {fixest} and {dreamerr} 1.4.0 fails pretty opaquely, e.g. from examples:

```
      > # Display the two results
      > iplot(list(res_sunab, res_sunab_3ref))
      Error: in coefplot(..., i.select = i.select, obje...:
       Argument `plot_prms` must be a named list. Problem: it is of length 0,
       while it should have a positive length.
```

1.5.0 relaxes rules around length-0 inputs.