### PR TITLE
Fix subscript out of bounds in predict() for stepwise models with i()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 
 ## Bug fixes
 
+- fix bug in `predict()` with `newdata` on a model extracted from a stepwise estimation containing `i()`: the check on the `i()` levels indexed the freshly built model-matrix info with the (possibly longer) stored one, leading to a "subscript out of bounds" error. Reported by @davi-dmittelstadt, #672.
+
 - fix bug in vcov(): following v0.14.0, the returned object was a matrix of class `fixest_vcov` -- which led to problem for matrix operations as it didn't inherit the matrix class. Now fixed, thanks to @strengejacke, #652.
 
 - fix bug in `xpd`: variable completion with `..` suffix now works when after an underscore (e.g. `xpd(~var_.., data = data.frame(var_1=1, var_2=2))`)

--- a/R/methods.R
+++ b/R/methods.R
@@ -2931,9 +2931,11 @@ predict.fixest = function(object, newdata, type = c("response", "link"), se.fit 
     mm_info_new = attr(matrix_linear, "model_matrix_info")
     if(!is.null(mm_info_new)){
       mm_info = object$model_matrix_info
-      # The order of creation is exactly the same (same fun used),
-      # so the two mm_info are identical in structure
-      for(i in seq_along(mm_info)){
+      # The order of creation is the same (same fun used), but the stored
+      # mm_info can hold more entries than the one rebuilt from newdata
+      # (e.g. models extracted from a stepwise estimation), so we only
+      # compare the entries that exist in both to avoid an out-of-bounds.
+      for(i in seq_len(min(length(mm_info), length(mm_info_new)))){
         mm_new_i = mm_info_new[[i]]
         mm_i = mm_info[[i]]
         if("coef_names_full" %in% names(mm_i)){

--- a/tests/fixest_tests.R
+++ b/tests/fixest_tests.R
@@ -2392,6 +2392,10 @@ test(predict(res, quoi), "err")
 res = feols(y ~ x1 | species^fe_bis, base, fixef.rm = "none")
 test(predict(res), predict(res, base))
 
+# predict with newdata on a model extracted from a stepwise estimation with i()
+res_sw = feols(y ~ sw(x1 + i(species), x1 + i(species)), base)
+test(predict(res_sw[[1]], newdata = base), predict(res_sw[[1]]))
+
 # Handling NAs properly
 base_NA = data.frame(a = 1:5, b = c(3:6, NA),
                      c = as.factor(c("a", "b", "a", "b", "a")))


### PR DESCRIPTION
Fixes #672.

`predict(newdata = ...)` errored with "subscript out of bounds" when the model was extracted from a stepwise estimation containing `i()`, e.g. `reg <- feols(am ~ sw(wt + i(cyl), wt + i(cyl)), mtcars); predict(reg[[1]], newdata = mtcars)`.

The `i()` level check in `predict()` looped over `seq_along(object$model_matrix_info)` while indexing `mm_info_new` (the info rebuilt from `newdata`). For a stepwise model the stored list can hold more entries than the rebuilt one, so `mm_info_new[[i]]` went past the end. I bound the loop to the entries present in both lists, which keeps the existing check on new `i()` levels intact.

Added a regression test in the PREDICT chunk. I don't have a local toolchain to build the package's C++ here, so I couldn't run the full suite, but the change is a one-line bound on the loop and the test mirrors the existing `i()` prediction tests.
